### PR TITLE
fix: failed to build PolyLib for mc 1.20.6

### DIFF
--- a/fabric/src/main/java/net/creeperhost/polylib/fabric/PolyLibFabric.java
+++ b/fabric/src/main/java/net/creeperhost/polylib/fabric/PolyLibFabric.java
@@ -13,6 +13,7 @@ import net.creeperhost.polylib.inventory.fluid.PolyFluidBlock;
 import net.creeperhost.polylib.inventory.fluid.PolyFluidHandler;
 import net.creeperhost.polylib.inventory.items.PolyInventoryBlock;
 import net.creeperhost.polylib.inventory.power.*;
+import net.fabricmc.api.EnvType;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerChunkEvents;


### PR DESCRIPTION
There's no PolyLib releases for mc 1.20.6. PolyLib for mc 1.20.4 cannot work in mc 1.20.6 (idk why, maybe because Architectury version is different?)

Not sure if there're other things to fix to make PolyLib work in mc 1.20.6, but at least with this MR we can build PolyLib.