### PR TITLE
build: modernize gradle — shadow jar, ModMenu dep, suppress javadoc warnings

### DIFF
--- a/buildSrc/src/main/groovy/multiloader-common.gradle
+++ b/buildSrc/src/main/groovy/multiloader-common.gradle
@@ -29,6 +29,10 @@ repositories {
         name = 'BlameJared'
         url = 'https://maven.blamejared.com'
     }
+    maven {
+        name = 'TerraformersMC'
+        url = 'https://maven.terraformersmc.com/releases'
+    }
 }
 
 sourcesJar {
@@ -53,6 +57,10 @@ jar {
                 'Built-On-Minecraft'    : minecraft_version
         ])
     }
+}
+
+javadoc {
+    options.addStringOption('Xdoclint:none', '-quiet')
 }
 
 processResources {

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -9,6 +9,8 @@ dependencies {
     implementation "net.fabricmc.fabric-api:fabric-api:${fabric_version}"
     implementation "blue.endless:jankson:1.2.1"
     shadow("blue.endless:jankson:1.2.1") { transitive = false }
+    // Mod Menu — soft optional dependency; only needed at compile time for ModMenuCompat
+    compileOnly "com.terraformersmc:modmenu:${modmenu_version}"
 }
 
 loom {
@@ -49,6 +51,14 @@ shadowJar {
     }
     relocate 'blue.endless.jankson', 'net.creeperhost.polylib.blue.endless.jankson'
     archiveClassifier = null
+}
+
+// Make the shadow jar the primary published artifact so consumers get Jankson bundled
+configurations {
+    [apiElements, runtimeElements].each { config ->
+        config.outgoing.artifacts.clear()
+        config.outgoing.artifact(shadowJar)
+    }
 }
 
 assemble.dependsOn(shadowJar)

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,8 +20,10 @@ minecraft_version_range=[26.1.2, 26.2)
 neo_form_version=26.1.2-1
 
 # Fabric, see https://fabricmc.net/develop/ for new versions
-fabric_version=0.145.4+26.1.2
-fabric_loader_version=0.18.6
+fabric_version=0.146.1+26.1.2
+fabric_loader_version=0.19.2
+# Mod Menu (soft dependency — compileOnly)
+modmenu_version=18.0.0-alpha.8
 
 # NeoForge, see https://projects.neoforged.net/neoforged/neoforge for new versions
 neoforge_version=26.1.2.7-beta

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -64,6 +64,14 @@ shadowJar {
     archiveClassifier = null
 }
 
+// Make the shadow jar the primary published artifact so consumers get Jankson bundled
+configurations {
+    [apiElements, runtimeElements].each { config ->
+        config.outgoing.artifacts.clear()
+        config.outgoing.artifact(shadowJar)
+    }
+}
+
 assemble.dependsOn(shadowJar)
 
 sourceSets.main.resources { srcDir 'src/generated/resources' }


### PR DESCRIPTION
Modernizes the build scripts to support the upcoming PolyLib extensions:

- NeoForge + Fabric: shadow jar as the primary published artifact
- Fabric: adds ModMenu `compileOnly` dependency (`modmenu_version=18.0.0-alpha.8`)
- `buildSrc/multiloader-common.gradle`: adds TerraformersMC maven repo; suppresses javadoc warnings
- `gradle.properties`: bumps `fabric_version` and `fabric_loader_version` to match MC 26.1.2
- `settings.gradle`: removes unused `testmod-common/fabric/neoforge` subproject includes

This is a prerequisite for `feat/config-panel` (ModMenu integration).