### PR TITLE
refactor: inline testmod into loader source sets, remove subprojects

### DIFF
--- a/common/src/main/java/net/creeperhost/polylib/testmod/MainMenuGuiInjection.java
+++ b/common/src/main/java/net/creeperhost/polylib/testmod/MainMenuGuiInjection.java
@@ -1,0 +1,67 @@
+package net.creeperhost.polylib.testmod;
+
+import net.creeperhost.polylib.client.modulargui.ModularGui;
+import net.creeperhost.polylib.client.modulargui.elements.*;
+import net.creeperhost.polylib.client.modulargui.lib.Constraints;
+import net.creeperhost.polylib.client.modulargui.lib.GuiProvider;
+import net.creeperhost.polylib.client.modulargui.lib.geometry.GeoParam;
+import net.creeperhost.polylib.client.modulargui.sprite.Material;
+import net.minecraft.ChatFormatting;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.components.PlainTextButton;
+import net.minecraft.client.gui.components.Renderable;
+import net.minecraft.client.gui.screens.TitleScreen;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.Identifier;
+
+import java.awt.*;
+
+import static net.creeperhost.polylib.client.modulargui.lib.geometry.Constraint.dynamic;
+
+public class MainMenuGuiInjection implements GuiProvider
+{
+    @Override
+    public void buildGui(ModularGui gui) {
+        TitleScreen screen = (TitleScreen) gui.getScreen();
+        gui.initFullscreenGui();
+        GuiElement<?> root = gui.getRoot();
+
+        GuiButton testButton = GuiButton.vanilla(root, Component.literal("Test Button"))
+                .onClick(() -> {});
+        Constraints.size(testButton, 100, 20);
+        Constraints.placeInside(testButton, root, Constraints.LayoutPos.TOP_LEFT, 10, 10);
+
+        GuiManipulable draggable = new GuiManipulable(root);
+        draggable.addMoveHandle(20);
+        draggable.enableCursors(true);
+        Constraints.size(draggable, 100, 20);
+        Constraints.placeInside(draggable, root, Constraints.LayoutPos.TOP_RIGHT, -10, 10);
+
+        Constraints.bind(GuiRectangle.toolTipBackground(draggable.getContentElement()), draggable.getContentElement());
+        Constraints.bind(new GuiText(draggable.getContentElement(), Component.literal("Drag Me!")), draggable.getContentElement());
+
+        //Draw some rainbow rectangles around the buttons because why not!
+        for (Renderable renderable : screen.renderables) {
+            if (!(renderable instanceof Button button) || renderable instanceof PlainTextButton) continue;
+
+            new GuiRectangle(root)
+                    .border(() -> 0xFF000000 | Color.getHSBColor((System.currentTimeMillis() % 5000) / 5000F, 1F, 1F).getRGB())
+                    .constrain(GeoParam.TOP, dynamic(() -> button.getY() - 1D))
+                    .constrain(GeoParam.LEFT, dynamic(() -> button.getX() - 1D))
+                    .constrain(GeoParam.WIDTH, dynamic(() -> button.getWidth() + 2D))
+                    .constrain(GeoParam.HEIGHT, dynamic(() -> button.getHeight() + 2D));
+        }
+
+        //Gotta have the DVD!
+        GuiDVD dvd = new GuiDVD(root);
+        Constraints.size(dvd, 40, 40);
+        Constraints.placeInside(dvd, root, Constraints.LayoutPos.BOTTOM_LEFT, 20, -20);
+        GuiTexture disc = new GuiTexture(dvd.getContentElement(), Material.fromRawTexture(Identifier.withDefaultNamespace("textures/item/music_disc_13.png")));
+        Constraints.bind(disc, dvd.getContentElement());
+        dvd.start();
+        dvd.onBounce(bounce -> disc.setColour(0xFF000000 | ChatFormatting.getById(1 + (bounce % 15)).getColor()));
+        GuiText text = new GuiText(dvd.getContentElement(), Component.literal("DVD"));
+        Constraints.size(text, 100, 8);
+        Constraints.placeInside(text, dvd.getContentElement(), Constraints.LayoutPos.BOTTOM_CENTER, 0, -8);
+    }
+}

--- a/common/src/main/java/net/creeperhost/polylib/testmod/TestModClientCommon.java
+++ b/common/src/main/java/net/creeperhost/polylib/testmod/TestModClientCommon.java
@@ -1,0 +1,12 @@
+package net.creeperhost.polylib.testmod;
+
+import net.creeperhost.polylib.client.modulargui.ModularGuiInjector;
+import net.minecraft.client.gui.screens.TitleScreen;
+
+public class TestModClientCommon
+{
+    public static void init()
+    {
+        ModularGuiInjector.registerInjection(e -> e instanceof TitleScreen, e -> new MainMenuGuiInjection());
+    }
+}

--- a/common/src/main/java/net/creeperhost/polylib/testmod/TestModCommon.java
+++ b/common/src/main/java/net/creeperhost/polylib/testmod/TestModCommon.java
@@ -1,0 +1,24 @@
+package net.creeperhost.polylib.testmod;
+
+import net.creeperhost.polylib.platform.Services;
+
+import net.creeperhost.polylib.registry.PolyRegistry;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockBehaviour;
+
+import java.util.function.Supplier;
+
+public class TestModCommon
+{
+    public static final PolyRegistry<Block> BLOCKS = PolyRegistry.create(Registries.BLOCK, "polylib");
+    public static final Supplier<Block> TEST_BLOCK = BLOCKS.register("test_block", () -> new Block(BlockBehaviour.Properties.of()));
+    public static void init()
+    {
+        BLOCKS.init();
+
+        if (Services.PLATFORM.isClient()) {
+            TestModClientCommon.init();
+        }
+    }
+}

--- a/fabric/src/main/java/net/creeperhost/polylib/testmod/TestModFabric.java
+++ b/fabric/src/main/java/net/creeperhost/polylib/testmod/TestModFabric.java
@@ -1,0 +1,9 @@
+package net.creeperhost.polylib.testmod;
+
+public class TestModFabric
+{
+    public static void init()
+    {
+
+    }
+}

--- a/neoforge/src/main/java/net/creeperhost/polylib/testmod/TestModNeoForge.java
+++ b/neoforge/src/main/java/net/creeperhost/polylib/testmod/TestModNeoForge.java
@@ -1,0 +1,9 @@
+package net.creeperhost.polylib.testmod;
+
+public class TestModNeoForge
+{
+    public static void init()
+    {
+
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -25,7 +25,3 @@ rootProject.name = 'PolyLib MultiLoader-Template'
 include('common')
 include('fabric')
 include('neoforge')
-
-include('testmod-common')
-include('testmod-fabric')
-include('testmod-neoforge')


### PR DESCRIPTION
Moves the testmod into a single inline package instead of separate subprojects, reducing build complexity. Removes the `testmod-common`, `testmod-fabric`, and `testmod-neoforge` subprojects and consolidates testmod code into the loader-specific source sets.