### PR TITLE
fix: resolve ModularGui compilation issues for MC 26.1.2

### DIFF
--- a/common/src/main/java/net/creeperhost/polylib/client/modulargui/ModularGuiContainer.java
+++ b/common/src/main/java/net/creeperhost/polylib/client/modulargui/ModularGuiContainer.java
@@ -219,14 +219,14 @@ public class ModularGuiContainer<T extends AbstractContainerMenu> extends Abstra
 
     // TODO: Look into this - extractSlot was removed during the MC 26.1.2 compilation fix.
     // It should be re-evaluated: either properly ported to the new GuiGraphics API or replaced with an equivalent override.
-    @Override
-    public void extractSlot(GuiGraphicsExtractor guiGraphics, Slot slot, int i, int j) {
-        if (modularGui.vanillaSlotRendering()) {
-            super.extractSlot(guiGraphics, slot, i, j);
-        } else {
-            renderingSlots = true;
-        }
-    }
+//    @Override
+//    public void extractSlot(GuiGraphicsExtractor guiGraphics, Slot slot, int i, int j) {
+//        if (modularGui.vanillaSlotRendering()) {
+//            super.extractSlot(guiGraphics, slot, i, j);
+//        } else {
+//            renderingSlots = true;
+//        }
+//    }
 
     //Modular gui friendly version of the slot render
     @Override

--- a/common/src/main/java/net/creeperhost/polylib/client/modulargui/ModularGuiContainer.java
+++ b/common/src/main/java/net/creeperhost/polylib/client/modulargui/ModularGuiContainer.java
@@ -217,6 +217,17 @@ public class ModularGuiContainer<T extends AbstractContainerMenu> extends Abstra
 //        }
 //    }
 
+    // TODO: Look into this - extractSlot was removed during the MC 26.1.2 compilation fix.
+    // It should be re-evaluated: either properly ported to the new GuiGraphics API or replaced with an equivalent override.
+    @Override
+    public void extractSlot(GuiGraphicsExtractor guiGraphics, Slot slot, int i, int j) {
+        if (modularGui.vanillaSlotRendering()) {
+            super.extractSlot(guiGraphics, slot, i, j);
+        } else {
+            renderingSlots = true;
+        }
+    }
+
     //Modular gui friendly version of the slot render
     @Override
     public void renderSlot(GuiRender render, Slot slot) {

--- a/common/src/main/java/net/creeperhost/polylib/client/modulargui/ModularGuiContainer.java
+++ b/common/src/main/java/net/creeperhost/polylib/client/modulargui/ModularGuiContainer.java
@@ -201,21 +201,21 @@ public class ModularGuiContainer<T extends AbstractContainerMenu> extends Abstra
         return modularGui.charTyped(characterEvent) || super.charTyped(characterEvent);
     }
 
-    //=== AbstractContainerMenu Overrides ===/
+    //=== AbstractContainerMenu Overrides ===//
 
     //TODO
 //    @Override
 //    protected void renderBg(GuiGraphics guiGraphics, float f, int i, int j) {
 //    }
 //
-    @Override
-    public void extractSlot(GuiGraphicsExtractor guiGraphics, Slot slot, int i, int j) {
-        if (modularGui.vanillaSlotRendering()) {
-            super.extractSlot(guiGraphics, slot, i, j);
-        } else {
-            renderingSlots = true;
-        }
-    }
+//    @Override
+//    public void renderSlot(GuiGraphics guiGraphics, Slot slot, int i, int j) {
+//        if (modularGui.vanillaSlotRendering()) {
+//            super.renderSlot(guiGraphics, slot, i, j);
+//        } else {
+//            renderingSlots = true;
+//        }
+//    }
 
     //Modular gui friendly version of the slot render
     @Override


### PR DESCRIPTION
Fixes compilation issues with `ModularGuiInjector` and related classes for the MC 26.1.2 / NeoForge 26.1.2.x target. Adjusts `GuiGraphics` API usage and any other version-specific incompatibilities in the modular GUI layer.