### PR TITLE
feat: add PolyLangContributions and PolyLibLangProvider for automatic lang datagen

### DIFF
--- a/common/src/main/java/net/creeperhost/polylib/data/lang/PolyLangContributions.java
+++ b/common/src/main/java/net/creeperhost/polylib/data/lang/PolyLangContributions.java
@@ -1,0 +1,76 @@
+package net.creeperhost.polylib.data.lang;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+/**
+ * Central store for PolyLib-managed default English translation strings.
+ *
+ * <p>Populated automatically by PolyLib registration APIs:
+ * <ul>
+ *   <li>{@code AccessibilityRegistrationBuilder} toggle/pair/category methods</li>
+ *   <li>{@code ConfigPanelRegistry.register(modId, labelKey, defaultEnglish, ...)} overloads</li>
+ *   <li>{@code PlayerClientSettingsRegistry.register(..., displayKey, displayEnglish)} overload</li>
+ *   <li>{@code PolyRegistry.register(name, defaultEnglish, supplier)} overload</li>
+ *   <li>Direct: {@link #contribute(String, String)}</li>
+ * </ul>
+ *
+ * <p>Consumed by {@code PolyLibLangProvider} in PolyLib's NeoForge module during datagen.
+ * Mod lang providers should extend {@code PolyLibLangProvider} instead of
+ * {@link net.neoforged.neoforge.common.data.LanguageProvider} directly to receive
+ * all contributions automatically.
+ *
+ * <p>Thread-safe. First registration wins — later contributions for an existing key are ignored,
+ * allowing mods to override PolyLib defaults by contributing earlier.
+ */
+public final class PolyLangContributions
+{
+    private PolyLangContributions() {}
+
+    private static final LinkedHashMap<String, String> ENTRIES = new LinkedHashMap<>();
+
+    /**
+     * Contributes a single translation key with its default English value.
+     * If the key is already present, the existing value is kept (first-registration wins).
+     *
+     * @param key           Translation key, e.g. {@code "discrafthonored.accessibility.blink_rescue"}
+     * @param defaultEnglish Human-readable English text, e.g. {@code "Save Me: Blink Rescue"}
+     */
+    public static synchronized void contribute(String key, String defaultEnglish)
+    {
+        ENTRIES.putIfAbsent(key, defaultEnglish);
+    }
+
+    /**
+     * Contributes all entries from the given map.
+     * For each key already present, the existing value is kept.
+     *
+     * @param entries Map of translationKey → defaultEnglish
+     */
+    public static synchronized void contributeAll(Map<String, String> entries)
+    {
+        entries.forEach(ENTRIES::putIfAbsent);
+    }
+
+    /**
+     * Returns an unmodifiable snapshot of all contributed entries in insertion order.
+     * Suitable for inspection, testing, or custom datagen.
+     */
+    public static synchronized Map<String, String> getAll()
+    {
+        return Collections.unmodifiableMap(new LinkedHashMap<>(ENTRIES));
+    }
+
+    /**
+     * Iterates all contributed entries, passing each {@code (key, defaultEnglish)} pair to the
+     * given consumer. Typically passed as {@code languageProvider::add} from a datagen provider.
+     *
+     * @param sink Receives each (translationKey, defaultEnglish) pair in insertion order
+     */
+    public static synchronized void drainTo(BiConsumer<String, String> sink)
+    {
+        ENTRIES.forEach(sink);
+    }
+}

--- a/neoforge/src/main/java/net/creeperhost/polylib/datagen/PolyLibLangProvider.java
+++ b/neoforge/src/main/java/net/creeperhost/polylib/datagen/PolyLibLangProvider.java
@@ -1,0 +1,100 @@
+package net.creeperhost.polylib.datagen;
+
+import net.creeperhost.polylib.data.lang.PolyLangContributions;
+import net.minecraft.data.PackOutput;
+import net.neoforged.neoforge.common.data.LanguageProvider;
+
+/**
+ * Abstract {@link LanguageProvider} that automatically includes every translation entry
+ * contributed to PolyLib's lang datagen system via any PolyLib registration API.
+ *
+ * <h3>Usage</h3>
+ * Extend this class in your mod's NeoForge datagen module instead of extending
+ * {@link LanguageProvider} directly:
+ * <pre>{@code
+ * public class ModLangProvider extends PolyLibLangProvider {
+ *     public ModLangProvider(PackOutput output) {
+ *         super(output, "mymod");
+ *     }
+ *
+ *     @Override
+ *     protected void addModTranslations() {
+ *         // Only entries NOT managed by PolyLib registration APIs.
+ *         // Items, blocks, and other objects registered with
+ *         //   PolyRegistry.register(name, defaultEnglish, supplier)
+ *         // and accessibility options registered with
+ *         //   AccessibilityOptionsRegistry.register(key, builder -> ...)
+ *         // are included AUTOMATICALLY — no add() calls needed here.
+ *         add("message.mymod.some_event", "Something happened!");
+ *     }
+ * }
+ * }</pre>
+ *
+ * <h3>What is auto-included</h3>
+ * Any key+English pair contributed to {@link PolyLangContributions} via:
+ * <ul>
+ *   <li>{@code AccessibilityOptionsRegistry.register(key, builder → ...)} —
+ *       all {@code .toggle()}, {@code .togglePair()}, and {@code .category()} labels</li>
+ *   <li>{@code ConfigPanelRegistry.register(modId, labelKey, defaultEnglish, factory, shortcut)}</li>
+ *   <li>{@code ConfigPanelRegistry.registerModularGui(modId, labelKey, defaultEnglish, factory, shortcut)}</li>
+ *   <li>{@code PlayerClientSettingsRegistry.register(..., displayNameKey, displayNameEnglish)}</li>
+ *   <li>{@code PolyRegistry.register(name, defaultEnglish, supplier)} — block/item names</li>
+ *   <li>{@code PolyLangContributions.contribute(key, english)} — direct contributions</li>
+ * </ul>
+ *
+ * <h3>Locale support</h3>
+ * Use {@link #PolyLibLangProvider(PackOutput, String, String)} to generate a locale other
+ * than {@code en_us}.
+ */
+public abstract class PolyLibLangProvider extends LanguageProvider
+{
+    protected PolyLibLangProvider(PackOutput output, String modId)
+    {
+        super(output, modId, "en_us");
+    }
+
+    protected PolyLibLangProvider(PackOutput output, String modId, String locale)
+    {
+        super(output, modId, locale);
+    }
+
+    /**
+     * Final — do not override. Drains all PolyLib-tracked contributions first, then
+     * calls {@link #addModTranslations()} for mod-specific manual entries.
+     *
+     * <p>If a key is contributed by both PolyLib and {@code addModTranslations()}, the
+     * manual call in {@code addModTranslations()} will overwrite the PolyLib default,
+     * giving mods full control to customise any auto-contributed string.
+     */
+    @Override
+    protected final void addTranslations()
+    {
+        // All PolyLib-managed contributions (accessibility labels, config panel buttons,
+        // settings type display names, registry object names, etc.)
+        PolyLangContributions.drainTo(this::add);
+
+        // Mod-specific manual entries — anything not managed by PolyLib APIs.
+        // Calling add() for a key already contributed above is fine — it will overwrite
+        // the PolyLib default with the mod's explicit value.
+        addModTranslations();
+    }
+
+    /**
+     * Override to add translation entries NOT automatically contributed via PolyLib APIs.
+     *
+     * <p>You do NOT need to add entries for:
+     * <ul>
+     *   <li>Items/blocks registered via {@code PolyRegistry.register(name, english, supplier)}</li>
+     *   <li>Accessibility toggle labels registered via {@code AccessibilityOptionsRegistry.register(key, builder)}</li>
+     *   <li>Config panel button labels registered via the string-key overloads of {@code ConfigPanelRegistry}</li>
+     *   <li>Settings type display names registered via the display-name overloads of {@code PlayerClientSettingsRegistry}</li>
+     * </ul>
+     *
+     * <p>You DO still need to add entries for:
+     * <ul>
+     *   <li>Items/blocks registered with the old {@code register(name, supplier)} overload (no English provided)</li>
+     *   <li>Chat messages, tooltips, subtitles, and any other keys not tied to a PolyLib registration</li>
+     * </ul>
+     */
+    protected abstract void addModTranslations();
+}


### PR DESCRIPTION
Adds automatic lang key datagen support for PolyLib and consuming mods.

- **`PolyLangContributions`** (`common`): thread-safe static registry of `translationKey → defaultEnglish` pairs. First-registration-wins. All PolyLib registration APIs feed into this automatically.
- **`PolyLibLangProvider`** (`neoforge`): abstract `LanguageProvider` subclass. Mod devs extend this instead of `LanguageProvider` directly; it auto-drains `PolyLangContributions` into the generated `en_us.json` at datagen time.