### PR TITLE
feat: add PlayerClientSettings and PlayerServerData sync systems

### DIFF
--- a/common/src/main/java/net/creeperhost/polylib/platform/Services.java
+++ b/common/src/main/java/net/creeperhost/polylib/platform/Services.java
@@ -2,6 +2,7 @@ package net.creeperhost.polylib.platform;
 
 import net.creeperhost.polylib.Constants;
 import net.creeperhost.polylib.platform.services.INetworkHelper;
+import net.creeperhost.polylib.platform.services.IPlayerDataHelper;
 import net.creeperhost.polylib.platform.services.IPlatformHelper;
 import net.creeperhost.polylib.platform.services.IRegisterHelper;
 
@@ -12,6 +13,7 @@ public class Services {
     public static final IPlatformHelper PLATFORM = load(IPlatformHelper.class);
     public static final INetworkHelper NETWORK = load(INetworkHelper.class);
     public static final IRegisterHelper REGISTER_HELPER = load(IRegisterHelper.class);
+    public static final IPlayerDataHelper PLAYER_DATA = load(IPlayerDataHelper.class);
 
     public static <T> T load(Class<T> clazz) {
 

--- a/common/src/main/java/net/creeperhost/polylib/platform/services/IPlayerDataHelper.java
+++ b/common/src/main/java/net/creeperhost/polylib/platform/services/IPlayerDataHelper.java
@@ -1,0 +1,47 @@
+package net.creeperhost.polylib.platform.services;
+
+import net.creeperhost.polylib.player.serverdata.PlayerServerDataStore;
+import net.creeperhost.polylib.player.serverdata.PlayerServerDataType;
+import net.creeperhost.polylib.player.settings.PlayerClientSettingsStore;
+import net.creeperhost.polylib.player.settings.PlayerClientSettingsType;
+import net.minecraft.server.level.ServerPlayer;
+
+import java.util.UUID;
+
+/**
+ * Platform service for persisting player data (both client settings and server data).
+ * NeoForge impl uses {@code getPersistentData()} (CompoundTag) for both.
+ * Fabric impl uses {@code AttachmentRegistry} for both.
+ */
+public interface IPlayerDataHelper
+{
+    /** Called when a {@link PlayerClientSettingsType} is registered. Allocates the platform storage slot. */
+    void registerType(PlayerClientSettingsType<?> type);
+
+    /**
+     * Load all persisted client-settings data for a player into the provided store.
+     * Called on PlayerLoggedInEvent / ServerPlayConnectionEvents.JOIN.
+     */
+    void loadAll(UUID playerUUID, ServerPlayer player, PlayerClientSettingsStore store);
+
+    /**
+     * Persist all dirty client-settings entries in the store.
+     * Must call {@link PlayerClientSettingsStore#clearDirty()} after a successful save.
+     */
+    void saveAll(UUID playerUUID, ServerPlayer player, PlayerClientSettingsStore store);
+
+    /** Called when a {@link PlayerServerDataType} is registered. Allocates the platform storage slot. */
+    void registerServerDataType(PlayerServerDataType<?> type);
+
+    /**
+     * Load all persisted server-data values for a player into the provided store.
+     * Called on PlayerLoggedInEvent / ServerPlayConnectionEvents.JOIN.
+     */
+    void loadServerData(UUID playerUUID, ServerPlayer player, PlayerServerDataStore store);
+
+    /**
+     * Persist all dirty server-data entries in the store.
+     * Must call {@link PlayerServerDataStore#clearDirty()} after a successful save.
+     */
+    void saveServerData(UUID playerUUID, ServerPlayer player, PlayerServerDataStore store);
+}

--- a/common/src/main/java/net/creeperhost/polylib/player/serverdata/PlayerServerDataClientCache.java
+++ b/common/src/main/java/net/creeperhost/polylib/player/serverdata/PlayerServerDataClientCache.java
@@ -1,0 +1,65 @@
+package net.creeperhost.polylib.player.serverdata;
+
+import io.netty.buffer.Unpooled;
+import net.minecraft.client.Minecraft;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Client-side read-only cache of server-authoritative player data values.
+ *
+ * <p>Values are received via {@link SyncPlayerServerDataS2CPayload} and decoded on demand
+ * using the type's {@code syncCodec}. This cache is keyed by type ID only (not UUID)
+ * because these values are always for the local/owning player.
+ *
+ * <p>Typical use: HUD rendering, client-side power availability checks.
+ * Never write to this; mutations go through {@link PlayerServerDataManager#set} on the server.
+ */
+public final class PlayerServerDataClientCache
+{
+    // typeId → raw bytes as received from S2C payload (encoded via syncCodec)
+    private static final Map<String, byte[]> RAW = new ConcurrentHashMap<>();
+
+    private PlayerServerDataClientCache() {}
+
+    /**
+     * Store raw bytes received via {@link SyncPlayerServerDataS2CPayload}.
+     * Called from the S2C packet handler on the client.
+     */
+    public static void receive(String typeId, byte[] data)
+    {
+        RAW.put(typeId, data);
+    }
+
+    /**
+     * Get the cached value for a type, decoded via the type's {@code syncCodec}.
+     * Returns the type's default if no data has been received yet.
+     *
+     * <p>This method is inexpensive but not free — it deserializes on every call.
+     * Cache the result in your renderer if called per-frame.
+     */
+    public static <T> T get(PlayerServerDataType<T> type)
+    {
+        if (type.syncCodec() == null) return type.defaultFactory().get();
+        byte[] data = RAW.get(type.id());
+        if (data == null) return type.defaultFactory().get();
+
+        Minecraft mc = Minecraft.getInstance();
+        if (mc.getConnection() == null) return type.defaultFactory().get();
+
+        RegistryFriendlyByteBuf buf = new RegistryFriendlyByteBuf(
+                Unpooled.wrappedBuffer(data),
+                mc.getConnection().registryAccess());
+        return type.syncCodec().decode(buf);
+    }
+
+    /**
+     * Clear all cached data. Call on client disconnect so stale values don't persist.
+     */
+    public static void clear()
+    {
+        RAW.clear();
+    }
+}

--- a/common/src/main/java/net/creeperhost/polylib/player/serverdata/PlayerServerDataClientCache.java
+++ b/common/src/main/java/net/creeperhost/polylib/player/serverdata/PlayerServerDataClientCache.java
@@ -3,6 +3,7 @@ package net.creeperhost.polylib.player.serverdata;
 import io.netty.buffer.Unpooled;
 import net.minecraft.client.Minecraft;
 import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.resources.Identifier;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -20,7 +21,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public final class PlayerServerDataClientCache
 {
     // typeId → raw bytes as received from S2C payload (encoded via syncCodec)
-    private static final Map<String, byte[]> RAW = new ConcurrentHashMap<>();
+    private static final Map<Identifier, byte[]> RAW = new ConcurrentHashMap<>();
 
     private PlayerServerDataClientCache() {}
 
@@ -28,7 +29,7 @@ public final class PlayerServerDataClientCache
      * Store raw bytes received via {@link SyncPlayerServerDataS2CPayload}.
      * Called from the S2C packet handler on the client.
      */
-    public static void receive(String typeId, byte[] data)
+    public static void receive(Identifier typeId, byte[] data)
     {
         RAW.put(typeId, data);
     }

--- a/common/src/main/java/net/creeperhost/polylib/player/serverdata/PlayerServerDataManager.java
+++ b/common/src/main/java/net/creeperhost/polylib/player/serverdata/PlayerServerDataManager.java
@@ -1,0 +1,143 @@
+package net.creeperhost.polylib.player.serverdata;
+
+import io.netty.buffer.Unpooled;
+import net.creeperhost.polylib.platform.Services;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.server.level.ServerPlayer;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Central server-side manager for {@link PlayerServerDataType} values.
+ *
+ * <p>Handles NBT persistence (via {@code IPlayerDataHelper}), optional S2C sync
+ * to the owning player, and player lifecycle (login / logout / respawn).
+ *
+ * <p>Server is always the authoritative source. Use {@link #get} / {@link #set}
+ * from server-side code only. Clients receive a read-only copy via
+ * {@link PlayerServerDataClientCache} when the type's {@code syncCodec} is non-null.
+ */
+public final class PlayerServerDataManager
+{
+    private static final Map<UUID, PlayerServerDataStore> STORES = new ConcurrentHashMap<>();
+
+    private PlayerServerDataManager() {}
+
+    /** Called when a player joins. Loads persisted data and syncs syncable types to the owner. */
+    public static void onPlayerLogin(ServerPlayer player)
+    {
+        UUID uuid = player.getUUID();
+        PlayerServerDataStore store = new PlayerServerDataStore();
+        STORES.put(uuid, store);
+        Services.PLAYER_DATA.loadServerData(uuid, player, store);
+
+        for (PlayerServerDataType<?> type : PlayerServerDataRegistry.getAll())
+        {
+            if (type.syncsToClient())
+                syncToOwner(player, type, store);
+        }
+    }
+
+    /**
+     * Called when a player leaves. Removes the in-memory store.
+     * Data is already persisted on every {@link #set} call.
+     */
+    public static void onPlayerLogout(UUID playerUUID)
+    {
+        STORES.remove(playerUUID);
+    }
+
+    /**
+     * Called on respawn. Copies {@code copyOnDeath} values from old store to new player.
+     * On NeoForge the UUID is stable so old/new UUID are the same; pass it for both.
+     * On Fabric, platform-level {@code copyOnDeath()} attachment handles storage automatically;
+     * this call re-syncs to the client after respawn.
+     */
+    public static void onPlayerRespawn(UUID oldUUID, ServerPlayer newPlayer)
+    {
+        PlayerServerDataStore oldStore = STORES.get(oldUUID);
+        if (oldStore == null) return;
+
+        PlayerServerDataStore newStore = STORES.computeIfAbsent(newPlayer.getUUID(),
+                k -> new PlayerServerDataStore());
+
+        for (PlayerServerDataType<?> type : PlayerServerDataRegistry.getAll())
+        {
+            if (type.copyOnDeath() && oldStore.has(type))
+                copyTyped(type, oldStore, newStore);
+        }
+
+        // Re-sync all syncable types to the client after respawn
+        for (PlayerServerDataType<?> type : PlayerServerDataRegistry.getAll())
+        {
+            if (type.syncsToClient())
+                syncToOwner(newPlayer, type, newStore);
+        }
+    }
+
+    /**
+     * Returns the current value for a player. Server-side only.
+     * Returns the type's default if the player has no active store.
+     */
+    public static <T> T get(ServerPlayer player, PlayerServerDataType<T> type)
+    {
+        PlayerServerDataStore store = STORES.get(player.getUUID());
+        if (store == null) return type.defaultFactory().get();
+        return store.get(type);
+    }
+
+    /**
+     * Set a value server-side. Persists immediately and syncs to owner if the type
+     * has a {@code syncCodec}. <b>Server-side only.</b>
+     */
+    public static <T> void set(ServerPlayer player, PlayerServerDataType<T> type, T value)
+    {
+        UUID uuid = player.getUUID();
+        PlayerServerDataStore store = STORES.computeIfAbsent(uuid, k -> new PlayerServerDataStore());
+        store.set(type, value);
+        Services.PLAYER_DATA.saveServerData(uuid, player, store);
+        if (type.syncsToClient())
+            syncToOwner(player, type, store);
+    }
+
+    private static <T> void syncToOwner(ServerPlayer owner,
+                                         PlayerServerDataType<T> type,
+                                         PlayerServerDataStore store)
+    {
+        StreamCodecHolder<T> holder = new StreamCodecHolder<>(type);
+        if (!holder.hasCodec()) return;
+
+        RegistryFriendlyByteBuf buf = new RegistryFriendlyByteBuf(
+                Unpooled.buffer(), owner.level().registryAccess());
+        holder.encode(buf, store.get(type));
+        byte[] data = new byte[buf.readableBytes()];
+        buf.readBytes(data);
+        buf.release();
+        Services.NETWORK.sendToPlayer(owner, new SyncPlayerServerDataS2CPayload(type.id(), data));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> void copyTyped(PlayerServerDataType<T> type,
+                                       PlayerServerDataStore src,
+                                       PlayerServerDataStore dst)
+    {
+        dst.load(type, src.get(type));
+    }
+
+    /**
+     * Helper to avoid raw-type warnings when calling syncCodec encode/decode.
+     * The type erasure is safe because we only ever create this from a typed
+     * {@link PlayerServerDataType}{@code <T>}.
+     */
+    @SuppressWarnings("unchecked")
+    private static final class StreamCodecHolder<T>
+    {
+        private final net.minecraft.network.codec.StreamCodec<RegistryFriendlyByteBuf, T> codec;
+
+        StreamCodecHolder(PlayerServerDataType<T> type) { this.codec = type.syncCodec(); }
+        boolean hasCodec() { return codec != null; }
+        void encode(RegistryFriendlyByteBuf buf, T value) { codec.encode(buf, value); }
+    }
+}

--- a/common/src/main/java/net/creeperhost/polylib/player/serverdata/PlayerServerDataRegistry.java
+++ b/common/src/main/java/net/creeperhost/polylib/player/serverdata/PlayerServerDataRegistry.java
@@ -4,6 +4,7 @@ import com.mojang.serialization.Codec;
 import net.creeperhost.polylib.platform.Services;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.resources.Identifier;
 import org.jetbrains.annotations.Nullable;
 import java.util.*;
 import java.util.function.Supplier;
@@ -14,7 +15,7 @@ import java.util.function.Supplier;
  */
 public final class PlayerServerDataRegistry
 {
-    private static final Map<String, PlayerServerDataType<?>> BY_ID = new LinkedHashMap<>();
+    private static final Map<Identifier, PlayerServerDataType<?>> BY_ID = new LinkedHashMap<>();
 
     private PlayerServerDataRegistry() {}
 
@@ -29,7 +30,7 @@ public final class PlayerServerDataRegistry
      * @param copyOnDeath    Whether the value survives player death/respawn
      * @return The typed token — store as a {@code public static final} constant
      */
-    public static <T> PlayerServerDataType<T> register(String id,
+    public static <T> PlayerServerDataType<T> register(Identifier id,
                                                         Codec<T> nbtCodec,
                                                         @Nullable StreamCodec<RegistryFriendlyByteBuf, T> syncCodec,
                                                         Supplier<T> defaultFactory,
@@ -47,7 +48,7 @@ public final class PlayerServerDataRegistry
     /**
      * Convenience overload — no S2C sync (server-only data).
      */
-    public static <T> PlayerServerDataType<T> register(String id,
+    public static <T> PlayerServerDataType<T> register(Identifier id,
                                                         Codec<T> nbtCodec,
                                                         Supplier<T> defaultFactory,
                                                         boolean copyOnDeath)
@@ -62,7 +63,7 @@ public final class PlayerServerDataRegistry
     }
 
     /** Lookup by namespaced ID — used by packet handlers. */
-    public static Optional<PlayerServerDataType<?>> byId(String id)
+    public static Optional<PlayerServerDataType<?>> byId(Identifier id)
     {
         return Optional.ofNullable(BY_ID.get(id));
     }

--- a/common/src/main/java/net/creeperhost/polylib/player/serverdata/PlayerServerDataRegistry.java
+++ b/common/src/main/java/net/creeperhost/polylib/player/serverdata/PlayerServerDataRegistry.java
@@ -1,0 +1,69 @@
+package net.creeperhost.polylib.player.serverdata;
+
+import com.mojang.serialization.Codec;
+import net.creeperhost.polylib.platform.Services;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.StreamCodec;
+import org.jetbrains.annotations.Nullable;
+import java.util.*;
+import java.util.function.Supplier;
+
+/**
+ * Registry for {@link PlayerServerDataType} tokens.
+ * All registration must happen before the server starts (mod constructor / init).
+ */
+public final class PlayerServerDataRegistry
+{
+    private static final Map<String, PlayerServerDataType<?>> BY_ID = new LinkedHashMap<>();
+
+    private PlayerServerDataRegistry() {}
+
+    /**
+     * Register a server-authoritative player data type with optional S2C sync to owner.
+     *
+     * @param id             Namespaced ID, e.g. {@code "discrafthonored:abilities"}
+     * @param nbtCodec       DFU {@link Codec} used for NBT persistence
+     * @param syncCodec      {@link StreamCodec} for S2C sync to the owning player.
+     *                       Pass {@code null} for server-only data (no client HUD sync).
+     * @param defaultFactory Supplier of a fresh default value when no data exists
+     * @param copyOnDeath    Whether the value survives player death/respawn
+     * @return The typed token — store as a {@code public static final} constant
+     */
+    public static <T> PlayerServerDataType<T> register(String id,
+                                                        Codec<T> nbtCodec,
+                                                        @Nullable StreamCodec<RegistryFriendlyByteBuf, T> syncCodec,
+                                                        Supplier<T> defaultFactory,
+                                                        boolean copyOnDeath)
+    {
+        if (BY_ID.containsKey(id))
+            throw new IllegalStateException("PlayerServerDataType already registered: " + id);
+
+        PlayerServerDataType<T> type = new PlayerServerDataType<>(id, nbtCodec, syncCodec, defaultFactory, copyOnDeath);
+        BY_ID.put(id, type);
+        Services.PLAYER_DATA.registerServerDataType(type);
+        return type;
+    }
+
+    /**
+     * Convenience overload — no S2C sync (server-only data).
+     */
+    public static <T> PlayerServerDataType<T> register(String id,
+                                                        Codec<T> nbtCodec,
+                                                        Supplier<T> defaultFactory,
+                                                        boolean copyOnDeath)
+    {
+        return register(id, nbtCodec, null, defaultFactory, copyOnDeath);
+    }
+
+    /** Returns all registered types in registration order. */
+    public static Collection<PlayerServerDataType<?>> getAll()
+    {
+        return Collections.unmodifiableCollection(BY_ID.values());
+    }
+
+    /** Lookup by namespaced ID — used by packet handlers. */
+    public static Optional<PlayerServerDataType<?>> byId(String id)
+    {
+        return Optional.ofNullable(BY_ID.get(id));
+    }
+}

--- a/common/src/main/java/net/creeperhost/polylib/player/serverdata/PlayerServerDataStore.java
+++ b/common/src/main/java/net/creeperhost/polylib/player/serverdata/PlayerServerDataStore.java
@@ -1,0 +1,55 @@
+package net.creeperhost.polylib.player.serverdata;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Per-player in-memory store for server-authoritative player data values.
+ * Internal to PolyLib — not part of the public API.
+ * Mirrors {@code PlayerClientSettingsStore} but keyed on {@link PlayerServerDataType}.
+ */
+public final class PlayerServerDataStore
+{
+    private final Map<PlayerServerDataType<?>, Object> cache = new HashMap<>();
+    private final Set<PlayerServerDataType<?>> dirty = new HashSet<>();
+
+    /** Get the current value, or the type's default if not yet loaded. */
+    @SuppressWarnings("unchecked")
+    public <T> T get(PlayerServerDataType<T> type)
+    {
+        return (T) cache.computeIfAbsent(type, t -> t.defaultFactory().get());
+    }
+
+    /** Set a value and mark it dirty for persistence. */
+    public <T> void set(PlayerServerDataType<T> type, T value)
+    {
+        cache.put(type, value);
+        dirty.add(type);
+    }
+
+    /** Set a value without marking dirty (used when loading persisted data). */
+    public <T> void load(PlayerServerDataType<T> type, T value)
+    {
+        cache.put(type, value);
+    }
+
+    /** Returns all types that have been modified since last save. */
+    public Set<PlayerServerDataType<?>> getDirty()
+    {
+        return dirty;
+    }
+
+    /** Clear the dirty set after a successful save. */
+    public void clearDirty()
+    {
+        dirty.clear();
+    }
+
+    /** Whether any type has a loaded value. */
+    public boolean has(PlayerServerDataType<?> type)
+    {
+        return cache.containsKey(type);
+    }
+}

--- a/common/src/main/java/net/creeperhost/polylib/player/serverdata/PlayerServerDataType.java
+++ b/common/src/main/java/net/creeperhost/polylib/player/serverdata/PlayerServerDataType.java
@@ -1,0 +1,57 @@
+package net.creeperhost.polylib.player.serverdata;
+
+import com.mojang.serialization.Codec;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.StreamCodec;
+import org.jetbrains.annotations.Nullable;
+import java.util.function.Supplier;
+
+/**
+ * Typed token representing a registered server-authoritative player data type.
+ *
+ * <p>Create via {@link PlayerServerDataRegistry#register} and store as a
+ * {@code public static final} constant in your mod.
+ *
+ * <p>This is the server-authority counterpart to {@code PlayerClientSettingsType}.
+ * The server owns the value; the client receives read-only S2C syncs for HUD use.
+ *
+ * @param <T> The value type
+ */
+public final class PlayerServerDataType<T>
+{
+    private final String id;
+    /** DFU Codec used for NBT persistence. */
+    private final Codec<T> nbtCodec;
+    /**
+     * StreamCodec used to serialize the value for S2C sync to the owning player.
+     * {@code null} means no client sync — value is server-only.
+     */
+    @Nullable
+    private final StreamCodec<RegistryFriendlyByteBuf, T> syncCodec;
+    private final Supplier<T> defaultFactory;
+    private final boolean copyOnDeath;
+
+    PlayerServerDataType(String id,
+                         Codec<T> nbtCodec,
+                         @Nullable StreamCodec<RegistryFriendlyByteBuf, T> syncCodec,
+                         Supplier<T> defaultFactory,
+                         boolean copyOnDeath)
+    {
+        this.id = id;
+        this.nbtCodec = nbtCodec;
+        this.syncCodec = syncCodec;
+        this.defaultFactory = defaultFactory;
+        this.copyOnDeath = copyOnDeath;
+    }
+
+    public String id() { return id; }
+    public Codec<T> nbtCodec() { return nbtCodec; }
+    @Nullable public StreamCodec<RegistryFriendlyByteBuf, T> syncCodec() { return syncCodec; }
+    public Supplier<T> defaultFactory() { return defaultFactory; }
+    public boolean copyOnDeath() { return copyOnDeath; }
+    /** Whether this type sends S2C sync packets to the owning player. */
+    public boolean syncsToClient() { return syncCodec != null; }
+
+    @Override
+    public String toString() { return "PlayerServerDataType[" + id + "]"; }
+}

--- a/common/src/main/java/net/creeperhost/polylib/player/serverdata/PlayerServerDataType.java
+++ b/common/src/main/java/net/creeperhost/polylib/player/serverdata/PlayerServerDataType.java
@@ -3,6 +3,7 @@ package net.creeperhost.polylib.player.serverdata;
 import com.mojang.serialization.Codec;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.resources.Identifier;
 import org.jetbrains.annotations.Nullable;
 import java.util.function.Supplier;
 
@@ -19,7 +20,7 @@ import java.util.function.Supplier;
  */
 public final class PlayerServerDataType<T>
 {
-    private final String id;
+    private final Identifier id;
     /** DFU Codec used for NBT persistence. */
     private final Codec<T> nbtCodec;
     /**
@@ -31,7 +32,7 @@ public final class PlayerServerDataType<T>
     private final Supplier<T> defaultFactory;
     private final boolean copyOnDeath;
 
-    PlayerServerDataType(String id,
+    PlayerServerDataType(Identifier id,
                          Codec<T> nbtCodec,
                          @Nullable StreamCodec<RegistryFriendlyByteBuf, T> syncCodec,
                          Supplier<T> defaultFactory,
@@ -44,7 +45,7 @@ public final class PlayerServerDataType<T>
         this.copyOnDeath = copyOnDeath;
     }
 
-    public String id() { return id; }
+    public Identifier id() { return id; }
     public Codec<T> nbtCodec() { return nbtCodec; }
     @Nullable public StreamCodec<RegistryFriendlyByteBuf, T> syncCodec() { return syncCodec; }
     public Supplier<T> defaultFactory() { return defaultFactory; }

--- a/common/src/main/java/net/creeperhost/polylib/player/serverdata/SyncPlayerServerDataS2CPayload.java
+++ b/common/src/main/java/net/creeperhost/polylib/player/serverdata/SyncPlayerServerDataS2CPayload.java
@@ -1,0 +1,45 @@
+package net.creeperhost.polylib.player.serverdata;
+
+import io.netty.buffer.ByteBuf;
+import net.creeperhost.polylib.Constants;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.resources.Identifier;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * S2C packet: server pushes an updated server-authoritative data value to the owning player.
+ * Sent only to the player whose data changed — never to other players.
+ */
+public record SyncPlayerServerDataS2CPayload(String typeId, byte[] data)
+        implements CustomPacketPayload
+{
+    public static final Type<SyncPlayerServerDataS2CPayload> TYPE = new Type<>(
+            Identifier.fromNamespaceAndPath(Constants.MOD_ID, "sync_server_data"));
+
+    public static final StreamCodec<ByteBuf, SyncPlayerServerDataS2CPayload> CODEC = StreamCodec.of(
+            (buf, payload) -> {
+                byte[] idBytes = payload.typeId().getBytes(StandardCharsets.UTF_8);
+                buf.writeInt(idBytes.length);
+                buf.writeBytes(idBytes);
+                buf.writeInt(payload.data().length);
+                buf.writeBytes(payload.data());
+            },
+            buf -> {
+                int idLen = buf.readInt();
+                byte[] idBytes = new byte[idLen];
+                buf.readBytes(idBytes);
+                String typeId = new String(idBytes, StandardCharsets.UTF_8);
+                int dataLen = buf.readInt();
+                byte[] data = new byte[dataLen];
+                buf.readBytes(data);
+                return new SyncPlayerServerDataS2CPayload(typeId, data);
+            });
+
+    @Override
+    public Type<? extends CustomPacketPayload> type()
+    {
+        return TYPE;
+    }
+}

--- a/common/src/main/java/net/creeperhost/polylib/player/serverdata/SyncPlayerServerDataS2CPayload.java
+++ b/common/src/main/java/net/creeperhost/polylib/player/serverdata/SyncPlayerServerDataS2CPayload.java
@@ -12,7 +12,7 @@ import java.nio.charset.StandardCharsets;
  * S2C packet: server pushes an updated server-authoritative data value to the owning player.
  * Sent only to the player whose data changed — never to other players.
  */
-public record SyncPlayerServerDataS2CPayload(String typeId, byte[] data)
+public record SyncPlayerServerDataS2CPayload(Identifier typeId, byte[] data)
         implements CustomPacketPayload
 {
     public static final Type<SyncPlayerServerDataS2CPayload> TYPE = new Type<>(
@@ -20,7 +20,7 @@ public record SyncPlayerServerDataS2CPayload(String typeId, byte[] data)
 
     public static final StreamCodec<ByteBuf, SyncPlayerServerDataS2CPayload> CODEC = StreamCodec.of(
             (buf, payload) -> {
-                byte[] idBytes = payload.typeId().getBytes(StandardCharsets.UTF_8);
+                byte[] idBytes = payload.typeId().toString().getBytes(StandardCharsets.UTF_8);
                 buf.writeInt(idBytes.length);
                 buf.writeBytes(idBytes);
                 buf.writeInt(payload.data().length);
@@ -30,7 +30,7 @@ public record SyncPlayerServerDataS2CPayload(String typeId, byte[] data)
                 int idLen = buf.readInt();
                 byte[] idBytes = new byte[idLen];
                 buf.readBytes(idBytes);
-                String typeId = new String(idBytes, StandardCharsets.UTF_8);
+                Identifier typeId = Identifier.parse(new String(idBytes, StandardCharsets.UTF_8));
                 int dataLen = buf.readInt();
                 byte[] data = new byte[dataLen];
                 buf.readBytes(data);

--- a/common/src/main/java/net/creeperhost/polylib/player/settings/BroadcastScope.java
+++ b/common/src/main/java/net/creeperhost/polylib/player/settings/BroadcastScope.java
@@ -1,0 +1,32 @@
+package net.creeperhost.polylib.player.settings;
+
+/**
+ * Controls which clients receive S2C sync packets when a PlayerClientSetting value changes.
+ */
+public enum BroadcastScope
+{
+    /**
+     * Stored server-side only. Never sent to any client.
+     * Use for server-computed preferences that don't affect rendering.
+     */
+    SERVER_ONLY,
+
+    /**
+     * Sent to the owning player only (e.g. per-player UI state, accessibility prefs).
+     */
+    SELF_ONLY,
+
+    /**
+     * Sent to all players currently online when changed.
+     * Also sent to newly joining players (full backfill on login).
+     * Use when all players need the data regardless of proximity.
+     */
+    ALL_ONLINE,
+
+    /**
+     * Sent only to players currently tracking the owner (within render/entity range).
+     * Backfill is automatic via StartTracking — no explicit login sync needed.
+     * Recommended for appearance/cosmetic data. More efficient than ALL_ONLINE.
+     */
+    TRACKING_RANGE
+}

--- a/common/src/main/java/net/creeperhost/polylib/player/settings/PlayerClientSettingSyncS2CPayload.java
+++ b/common/src/main/java/net/creeperhost/polylib/player/settings/PlayerClientSettingSyncS2CPayload.java
@@ -12,7 +12,7 @@ import java.util.UUID;
 /**
  * S2C: server broadcasts a PlayerClientSetting value update to clients per the type's {@link BroadcastScope}.
  */
-public record PlayerClientSettingSyncS2CPayload(UUID playerUUID, String typeId, byte[] data)
+public record PlayerClientSettingSyncS2CPayload(UUID playerUUID, Identifier typeId, byte[] data)
         implements CustomPacketPayload
 {
     public static final Type<PlayerClientSettingSyncS2CPayload> TYPE = new Type<>(
@@ -23,7 +23,7 @@ public record PlayerClientSettingSyncS2CPayload(UUID playerUUID, String typeId, 
             {
                 buf.writeLong(payload.playerUUID().getMostSignificantBits());
                 buf.writeLong(payload.playerUUID().getLeastSignificantBits());
-                byte[] idBytes = payload.typeId().getBytes(StandardCharsets.UTF_8);
+                byte[] idBytes = payload.typeId().toString().getBytes(StandardCharsets.UTF_8);
                 buf.writeInt(idBytes.length);
                 buf.writeBytes(idBytes);
                 buf.writeInt(payload.data().length);
@@ -37,7 +37,7 @@ public record PlayerClientSettingSyncS2CPayload(UUID playerUUID, String typeId, 
                 int idLen = buf.readInt();
                 byte[] idBytes = new byte[idLen];
                 buf.readBytes(idBytes);
-                String typeId = new String(idBytes, StandardCharsets.UTF_8);
+                Identifier typeId = Identifier.parse(new String(idBytes, StandardCharsets.UTF_8));
                 int dataLen = buf.readInt();
                 byte[] data = new byte[dataLen];
                 buf.readBytes(data);

--- a/common/src/main/java/net/creeperhost/polylib/player/settings/PlayerClientSettingSyncS2CPayload.java
+++ b/common/src/main/java/net/creeperhost/polylib/player/settings/PlayerClientSettingSyncS2CPayload.java
@@ -1,0 +1,52 @@
+package net.creeperhost.polylib.player.settings;
+
+import io.netty.buffer.ByteBuf;
+import net.creeperhost.polylib.Constants;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.resources.Identifier;
+
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+/**
+ * S2C: server broadcasts a PlayerClientSetting value update to clients per the type's {@link BroadcastScope}.
+ */
+public record PlayerClientSettingSyncS2CPayload(UUID playerUUID, String typeId, byte[] data)
+        implements CustomPacketPayload
+{
+    public static final Type<PlayerClientSettingSyncS2CPayload> TYPE = new Type<>(
+            Identifier.fromNamespaceAndPath(Constants.MOD_ID, "player_setting_sync"));
+
+    public static final StreamCodec<ByteBuf, PlayerClientSettingSyncS2CPayload> CODEC = StreamCodec.of(
+            (buf, payload) ->
+            {
+                buf.writeLong(payload.playerUUID().getMostSignificantBits());
+                buf.writeLong(payload.playerUUID().getLeastSignificantBits());
+                byte[] idBytes = payload.typeId().getBytes(StandardCharsets.UTF_8);
+                buf.writeInt(idBytes.length);
+                buf.writeBytes(idBytes);
+                buf.writeInt(payload.data().length);
+                buf.writeBytes(payload.data());
+            },
+            buf ->
+            {
+                long msb = buf.readLong();
+                long lsb = buf.readLong();
+                UUID playerUUID = new UUID(msb, lsb);
+                int idLen = buf.readInt();
+                byte[] idBytes = new byte[idLen];
+                buf.readBytes(idBytes);
+                String typeId = new String(idBytes, StandardCharsets.UTF_8);
+                int dataLen = buf.readInt();
+                byte[] data = new byte[dataLen];
+                buf.readBytes(data);
+                return new PlayerClientSettingSyncS2CPayload(playerUUID, typeId, data);
+            });
+
+    @Override
+    public Type<? extends CustomPacketPayload> type()
+    {
+        return TYPE;
+    }
+}

--- a/common/src/main/java/net/creeperhost/polylib/player/settings/PlayerClientSettingsClientCache.java
+++ b/common/src/main/java/net/creeperhost/polylib/player/settings/PlayerClientSettingsClientCache.java
@@ -3,6 +3,7 @@ package net.creeperhost.polylib.player.settings;
 import io.netty.buffer.Unpooled;
 import net.minecraft.client.Minecraft;
 import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.resources.Identifier;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -16,14 +17,14 @@ import java.util.concurrent.ConcurrentHashMap;
 public final class PlayerClientSettingsClientCache
 {
     // Outer key: player UUID. Inner key: type ID. Value: raw serialized bytes.
-    private static final Map<UUID, Map<String, byte[]>> RAW = new ConcurrentHashMap<>();
+    private static final Map<UUID, Map<Identifier, byte[]>> RAW = new ConcurrentHashMap<>();
 
     private PlayerClientSettingsClientCache() {}
 
     /**
      * Store raw bytes for a player+type. Called from S2C packet handler.
      */
-    public static void receive(UUID playerUUID, String typeId, byte[] data)
+    public static void receive(UUID playerUUID, Identifier typeId, byte[] data)
     {
         RAW.computeIfAbsent(playerUUID, k -> new ConcurrentHashMap<>()).put(typeId, data);
     }
@@ -33,7 +34,7 @@ public final class PlayerClientSettingsClientCache
      */
     public static <T> T getFor(UUID playerUUID, PlayerClientSettingsType<T> type)
     {
-        Map<String, byte[]> playerMap = RAW.get(playerUUID);
+        Map<Identifier, byte[]> playerMap = RAW.get(playerUUID);
         if (playerMap == null) return type.defaultFactory().get();
         byte[] data = playerMap.get(type.id());
         if (data == null) return type.defaultFactory().get();

--- a/common/src/main/java/net/creeperhost/polylib/player/settings/PlayerClientSettingsClientCache.java
+++ b/common/src/main/java/net/creeperhost/polylib/player/settings/PlayerClientSettingsClientCache.java
@@ -1,0 +1,65 @@
+package net.creeperhost.polylib.player.settings;
+
+import io.netty.buffer.Unpooled;
+import net.minecraft.client.Minecraft;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Client-side cache of PlayerClientSettings values received via S2C sync packets.
+ * Replaces per-mod caches like {@code PlayerAppearanceCache}.
+ */
+public final class PlayerClientSettingsClientCache
+{
+    // Outer key: player UUID. Inner key: type ID. Value: raw serialized bytes.
+    private static final Map<UUID, Map<String, byte[]>> RAW = new ConcurrentHashMap<>();
+
+    private PlayerClientSettingsClientCache() {}
+
+    /**
+     * Store raw bytes for a player+type. Called from S2C packet handler.
+     */
+    public static void receive(UUID playerUUID, String typeId, byte[] data)
+    {
+        RAW.computeIfAbsent(playerUUID, k -> new ConcurrentHashMap<>()).put(typeId, data);
+    }
+
+    /**
+     * Get the cached value for a player and type, or the default if not cached.
+     */
+    public static <T> T getFor(UUID playerUUID, PlayerClientSettingsType<T> type)
+    {
+        Map<String, byte[]> playerMap = RAW.get(playerUUID);
+        if (playerMap == null) return type.defaultFactory().get();
+        byte[] data = playerMap.get(type.id());
+        if (data == null) return type.defaultFactory().get();
+
+        Minecraft mc = Minecraft.getInstance();
+        if (mc.getConnection() == null) return type.defaultFactory().get();
+
+        RegistryFriendlyByteBuf buf = new RegistryFriendlyByteBuf(
+                Unpooled.wrappedBuffer(data),
+                mc.getConnection().registryAccess());
+        return type.codec().decode(buf);
+    }
+
+    /**
+     * Remove cached data for one player (e.g. on disconnect/leave).
+     */
+    public static void evict(UUID playerUUID)
+    {
+        RAW.remove(playerUUID);
+    }
+
+    /**
+     * Clear all cached data. Called on client disconnect.
+     */
+    public static void clear()
+    {
+        RAW.clear();
+    }
+}

--- a/common/src/main/java/net/creeperhost/polylib/player/settings/PlayerClientSettingsManager.java
+++ b/common/src/main/java/net/creeperhost/polylib/player/settings/PlayerClientSettingsManager.java
@@ -4,6 +4,7 @@ import io.netty.buffer.Unpooled;
 import net.creeperhost.polylib.platform.Services;
 import net.minecraft.core.RegistryAccess;
 import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.resources.Identifier;
 import net.minecraft.server.level.ServerPlayer;
 
 import java.util.Map;
@@ -83,7 +84,7 @@ public final class PlayerClientSettingsManager
     }
 
     /** Called when server receives {@link UpdatePlayerClientSettingC2SPayload}. */
-    public static void applyFromClient(ServerPlayer player, String typeId, byte[] data)
+    public static void applyFromClient(ServerPlayer player, Identifier typeId, byte[] data)
     {
         PlayerClientSettingsRegistry.byId(typeId).ifPresent(type -> {
             UUID uuid = player.getUUID();

--- a/common/src/main/java/net/creeperhost/polylib/player/settings/PlayerClientSettingsManager.java
+++ b/common/src/main/java/net/creeperhost/polylib/player/settings/PlayerClientSettingsManager.java
@@ -1,0 +1,208 @@
+package net.creeperhost.polylib.player.settings;
+
+import io.netty.buffer.Unpooled;
+import net.creeperhost.polylib.platform.Services;
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.server.level.ServerPlayer;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Central server-side manager for PlayerClientSettings.
+ * Handles persistence, sync, and incoming C2S updates.
+ */
+public final class PlayerClientSettingsManager
+{
+    private static final Map<UUID, PlayerClientSettingsStore> STORES = new ConcurrentHashMap<>();
+
+    private PlayerClientSettingsManager() {}
+
+    /** Called when a player joins. Loads persisted data and syncs to appropriate clients. */
+    public static void onPlayerLogin(ServerPlayer player)
+    {
+        UUID uuid = player.getUUID();
+        PlayerClientSettingsStore store = new PlayerClientSettingsStore();
+        STORES.put(uuid, store);
+        Services.PLAYER_DATA.loadAll(uuid, player, store);
+
+        // Sync to the joining player (their own settings back to themselves)
+        // and broadcast to others per scope
+        for (PlayerClientSettingsType<?> type : PlayerClientSettingsRegistry.getAll())
+        {
+            syncToRelevant(player, type, store, true);
+        }
+    }
+
+    /** Called when a player leaves. Store is discarded — persistence happens on each {@link #set} call. */
+    public static void onPlayerLogout(UUID playerUUID)
+    {
+        STORES.remove(playerUUID);
+    }
+
+    /** Called on respawn. Copies settings from old UUID to new player if copyOnDeath is true. */
+    public static void onPlayerRespawn(UUID oldUUID, ServerPlayer newPlayer)
+    {
+        PlayerClientSettingsStore oldStore = STORES.get(oldUUID);
+        if (oldStore == null) return;
+
+        PlayerClientSettingsStore newStore = STORES.computeIfAbsent(newPlayer.getUUID(),
+                k -> new PlayerClientSettingsStore());
+
+        for (PlayerClientSettingsType<?> type : PlayerClientSettingsRegistry.getAll())
+        {
+            if (type.copyOnDeath() && oldStore.has(type))
+            {
+                copyTyped(type, oldStore, newStore);
+            }
+        }
+
+        // Re-sync after respawn
+        for (PlayerClientSettingsType<?> type : PlayerClientSettingsRegistry.getAll())
+        {
+            syncToRelevant(newPlayer, type, newStore, false);
+        }
+    }
+
+    /** Called when a player starts tracking another. Backfills TRACKING_RANGE data. */
+    public static void syncTrackingRange(ServerPlayer tracked, ServerPlayer tracker)
+    {
+        UUID trackedUUID = tracked.getUUID();
+        PlayerClientSettingsStore store = STORES.get(trackedUUID);
+        if (store == null) return;
+
+        for (PlayerClientSettingsType<?> type : PlayerClientSettingsRegistry.getAll())
+        {
+            if (type.scope() == BroadcastScope.TRACKING_RANGE)
+            {
+                sendToPlayer(tracker, trackedUUID, type, store);
+            }
+        }
+    }
+
+    /** Called when server receives {@link UpdatePlayerClientSettingC2SPayload}. */
+    public static void applyFromClient(ServerPlayer player, String typeId, byte[] data)
+    {
+        PlayerClientSettingsRegistry.byId(typeId).ifPresent(type -> {
+            UUID uuid = player.getUUID();
+            PlayerClientSettingsStore store = STORES.computeIfAbsent(uuid,
+                    k -> new PlayerClientSettingsStore());
+            applyTyped(type, player, store, data);
+        });
+    }
+
+    /** Returns the current value for a player. Server-side only. */
+    public static <T> T get(UUID playerUUID, PlayerClientSettingsType<T> type)
+    {
+        PlayerClientSettingsStore store = STORES.get(playerUUID);
+        if (store == null) return type.defaultFactory().get();
+        return store.get(type);
+    }
+
+    /** Sets a value server-side. Persists and broadcasts per {@link BroadcastScope}. */
+    public static <T> void set(ServerPlayer player, PlayerClientSettingsType<T> type, T value)
+    {
+        UUID uuid = player.getUUID();
+        PlayerClientSettingsStore store = STORES.computeIfAbsent(uuid,
+                k -> new PlayerClientSettingsStore());
+        store.set(type, value);
+        Services.PLAYER_DATA.saveAll(uuid, player, store);
+        syncToRelevant(player, type, store, false);
+    }
+
+    /**
+     * Sends the current value to the server. Client-side.
+     * Pass {@code Minecraft.getInstance().getConnection().registryAccess()} as the registry access.
+     */
+    public static <T> void sendToServer(PlayerClientSettingsType<T> type, T value, RegistryAccess registryAccess)
+    {
+        RegistryFriendlyByteBuf buf = new RegistryFriendlyByteBuf(
+                Unpooled.buffer(),
+                registryAccess);
+        type.codec().encode(buf, value);
+        byte[] data = new byte[buf.readableBytes()];
+        buf.readBytes(data);
+        buf.release();
+        Services.NETWORK.sendToServer(new UpdatePlayerClientSettingC2SPayload(type.id(), data));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> void applyTyped(PlayerClientSettingsType<T> type,
+                                       ServerPlayer player,
+                                       PlayerClientSettingsStore store,
+                                       byte[] data)
+    {
+        RegistryFriendlyByteBuf buf = new RegistryFriendlyByteBuf(
+                Unpooled.wrappedBuffer(data),
+                player.level().registryAccess());
+        T value = type.codec().decode(buf);
+        store.set(type, value);
+        Services.PLAYER_DATA.saveAll(player.getUUID(), player, store);
+        syncToRelevant(player, type, store, false);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> void copyTyped(PlayerClientSettingsType<T> type,
+                                      PlayerClientSettingsStore src,
+                                      PlayerClientSettingsStore dst)
+    {
+        dst.load(type, src.get(type));
+    }
+
+    private static <T> void syncToRelevant(ServerPlayer owner,
+                                           PlayerClientSettingsType<T> type,
+                                           PlayerClientSettingsStore store,
+                                           boolean isLogin)
+    {
+        BroadcastScope scope = type.scope();
+        if (scope == BroadcastScope.SERVER_ONLY) return;
+
+        UUID uuid = owner.getUUID();
+
+        switch (scope)
+        {
+            case SELF_ONLY:
+                sendToPlayer(owner, uuid, type, store);
+                break;
+            case ALL_ONLINE:
+                ((net.minecraft.server.level.ServerLevel) owner.level()).getServer().getPlayerList().getPlayers().forEach(p ->
+                        sendToPlayer(p, uuid, type, store));
+                break;
+            case TRACKING_RANGE:
+                if (isLogin) sendToPlayer(owner, uuid, type, store);
+                if (!isLogin)
+                {
+                    ((net.minecraft.server.level.ServerLevel) owner.level()).getServer().getPlayerList().getPlayers().forEach(p -> {
+                        if (p.getUUID().equals(uuid)) return;
+                        if (p.level() == owner.level()
+                                && p.distanceToSqr(owner) <= 128 * 128)
+                        {
+                            sendToPlayer(p, uuid, type, store);
+                        }
+                    });
+                    sendToPlayer(owner, uuid, type, store);
+                }
+                break;
+            default:
+                break;
+        }
+    }
+
+    private static <T> void sendToPlayer(ServerPlayer target,
+                                         UUID ownerUUID,
+                                         PlayerClientSettingsType<T> type,
+                                         PlayerClientSettingsStore store)
+    {
+        RegistryFriendlyByteBuf buf = new RegistryFriendlyByteBuf(
+                Unpooled.buffer(),
+                ((net.minecraft.server.level.ServerLevel) target.level()).getServer().registryAccess());
+        type.codec().encode(buf, store.get(type));
+        byte[] data = new byte[buf.readableBytes()];
+        buf.readBytes(data);
+        buf.release();
+        Services.NETWORK.sendToPlayer(target,
+                new PlayerClientSettingSyncS2CPayload(ownerUUID, type.id(), data));
+    }
+}

--- a/common/src/main/java/net/creeperhost/polylib/player/settings/PlayerClientSettingsRegistry.java
+++ b/common/src/main/java/net/creeperhost/polylib/player/settings/PlayerClientSettingsRegistry.java
@@ -1,5 +1,6 @@
 package net.creeperhost.polylib.player.settings;
 
+// TODO: depends on feat/lang-datagen PR being merged — PolyLangContributions lives there
 import net.creeperhost.polylib.data.lang.PolyLangContributions;
 import net.creeperhost.polylib.platform.Services;
 import net.minecraft.network.RegistryFriendlyByteBuf;

--- a/common/src/main/java/net/creeperhost/polylib/player/settings/PlayerClientSettingsRegistry.java
+++ b/common/src/main/java/net/creeperhost/polylib/player/settings/PlayerClientSettingsRegistry.java
@@ -1,0 +1,91 @@
+package net.creeperhost.polylib.player.settings;
+
+import net.creeperhost.polylib.data.lang.PolyLangContributions;
+import net.creeperhost.polylib.platform.Services;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.StreamCodec;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+/**
+ * Registry for {@link PlayerClientSettingsType} tokens.
+ * All registration must happen before the server starts (typically in mod constructor or init).
+ */
+public final class PlayerClientSettingsRegistry
+{
+    private static final Map<String, PlayerClientSettingsType<?>> BY_ID = new LinkedHashMap<>();
+
+    private PlayerClientSettingsRegistry() {}
+
+    /**
+     * Register a new player client setting type.
+     *
+     * @param id             Namespaced ID, e.g. {@code "discrafthonored:appearance"}
+     * @param codec          StreamCodec for serialization
+     * @param defaultFactory Supplier for default value when no data exists
+     * @param scope          Who receives S2C sync when the value changes
+     * @param copyOnDeath    Whether the value is preserved through player death/respawn
+     * @return Typed token — store as a {@code public static final} constant
+     */
+    public static <T> PlayerClientSettingsType<T> register(String id,
+                                                           StreamCodec<RegistryFriendlyByteBuf, T> codec,
+                                                           Supplier<T> defaultFactory,
+                                                           BroadcastScope scope,
+                                                           boolean copyOnDeath)
+    {
+        return register(id, codec, defaultFactory, scope, copyOnDeath, null, null);
+    }
+
+    /**
+     * Register with an optional display name for UI panels. If both key and English are non-null,
+     * contributes them to {@link PolyLangContributions} for lang datagen.
+     *
+     * @param id                 Namespaced ID, e.g. {@code "discrafthonored:appearance"}
+     * @param codec              StreamCodec for serialization
+     * @param defaultFactory     Supplier for default value when no data exists
+     * @param scope              Who receives S2C sync when the value changes
+     * @param copyOnDeath        Whether the value is preserved through player death/respawn
+     * @param displayNameKey     Translation key for the settings type's display name, or null
+     * @param displayNameEnglish Default English text for the display name, or null
+     * @return Typed token — store as a {@code public static final} constant
+     */
+    public static <T> PlayerClientSettingsType<T> register(String id,
+                                                           StreamCodec<RegistryFriendlyByteBuf, T> codec,
+                                                           Supplier<T> defaultFactory,
+                                                           BroadcastScope scope,
+                                                           boolean copyOnDeath,
+                                                           @Nullable String displayNameKey,
+                                                           @Nullable String displayNameEnglish)
+    {
+        if (BY_ID.containsKey(id))
+            throw new IllegalStateException("PlayerClientSettingsType already registered: " + id);
+
+        if (displayNameKey != null && displayNameEnglish != null)
+            PolyLangContributions.contribute(displayNameKey, displayNameEnglish);
+
+        PlayerClientSettingsType<T> type = new PlayerClientSettingsType<>(
+                id, codec, defaultFactory, scope, copyOnDeath, displayNameKey);
+        BY_ID.put(id, type);
+        // Notify IPlayerDataHelper so it can allocate its platform storage slot
+        Services.PLAYER_DATA.registerType(type);
+        return type;
+    }
+
+    /** Returns all registered types — used internally by PolyLib event handlers. */
+    public static Collection<PlayerClientSettingsType<?>> getAll()
+    {
+        return Collections.unmodifiableCollection(BY_ID.values());
+    }
+
+    /** Lookup by namespaced ID — used by packet handlers. */
+    public static Optional<PlayerClientSettingsType<?>> byId(String id)
+    {
+        return Optional.ofNullable(BY_ID.get(id));
+    }
+}

--- a/common/src/main/java/net/creeperhost/polylib/player/settings/PlayerClientSettingsRegistry.java
+++ b/common/src/main/java/net/creeperhost/polylib/player/settings/PlayerClientSettingsRegistry.java
@@ -4,6 +4,7 @@ import net.creeperhost.polylib.data.lang.PolyLangContributions;
 import net.creeperhost.polylib.platform.Services;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.resources.Identifier;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
@@ -19,7 +20,7 @@ import java.util.function.Supplier;
  */
 public final class PlayerClientSettingsRegistry
 {
-    private static final Map<String, PlayerClientSettingsType<?>> BY_ID = new LinkedHashMap<>();
+    private static final Map<Identifier, PlayerClientSettingsType<?>> BY_ID = new LinkedHashMap<>();
 
     private PlayerClientSettingsRegistry() {}
 
@@ -33,7 +34,7 @@ public final class PlayerClientSettingsRegistry
      * @param copyOnDeath    Whether the value is preserved through player death/respawn
      * @return Typed token — store as a {@code public static final} constant
      */
-    public static <T> PlayerClientSettingsType<T> register(String id,
+    public static <T> PlayerClientSettingsType<T> register(Identifier id,
                                                            StreamCodec<RegistryFriendlyByteBuf, T> codec,
                                                            Supplier<T> defaultFactory,
                                                            BroadcastScope scope,
@@ -55,7 +56,7 @@ public final class PlayerClientSettingsRegistry
      * @param displayNameEnglish Default English text for the display name, or null
      * @return Typed token — store as a {@code public static final} constant
      */
-    public static <T> PlayerClientSettingsType<T> register(String id,
+    public static <T> PlayerClientSettingsType<T> register(Identifier id,
                                                            StreamCodec<RegistryFriendlyByteBuf, T> codec,
                                                            Supplier<T> defaultFactory,
                                                            BroadcastScope scope,
@@ -84,7 +85,7 @@ public final class PlayerClientSettingsRegistry
     }
 
     /** Lookup by namespaced ID — used by packet handlers. */
-    public static Optional<PlayerClientSettingsType<?>> byId(String id)
+    public static Optional<PlayerClientSettingsType<?>> byId(Identifier id)
     {
         return Optional.ofNullable(BY_ID.get(id));
     }

--- a/common/src/main/java/net/creeperhost/polylib/player/settings/PlayerClientSettingsStore.java
+++ b/common/src/main/java/net/creeperhost/polylib/player/settings/PlayerClientSettingsStore.java
@@ -1,0 +1,55 @@
+package net.creeperhost.polylib.player.settings;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Per-player in-memory store for PlayerClientSettings values.
+ * Internal to PolyLib — not part of public API.
+ * Provides zero-deserialization reads via a typed object cache.
+ */
+public final class PlayerClientSettingsStore
+{
+    private final Map<PlayerClientSettingsType<?>, Object> cache = new HashMap<>();
+    private final Set<PlayerClientSettingsType<?>> dirty = new HashSet<>();
+
+    /** Get the current value, or the type's default if not yet loaded. */
+    @SuppressWarnings("unchecked")
+    public <T> T get(PlayerClientSettingsType<T> type)
+    {
+        return (T) cache.computeIfAbsent(type, t -> t.defaultFactory().get());
+    }
+
+    /** Set a value and mark it dirty for persistence. */
+    public <T> void set(PlayerClientSettingsType<T> type, T value)
+    {
+        cache.put(type, value);
+        dirty.add(type);
+    }
+
+    /** Set a value without marking dirty (used when loading persisted data). */
+    public <T> void load(PlayerClientSettingsType<T> type, T value)
+    {
+        cache.put(type, value);
+    }
+
+    /** Returns all types that have been modified since last save. */
+    public Set<PlayerClientSettingsType<?>> getDirty()
+    {
+        return dirty;
+    }
+
+    /** Clear the dirty set after a successful save. */
+    public void clearDirty()
+    {
+        dirty.clear();
+    }
+
+    /** Whether any type has a loaded value (i.e. data was loaded from persistence). */
+    public boolean has(PlayerClientSettingsType<?> type)
+    {
+        return cache.containsKey(type);
+    }
+}

--- a/common/src/main/java/net/creeperhost/polylib/player/settings/PlayerClientSettingsType.java
+++ b/common/src/main/java/net/creeperhost/polylib/player/settings/PlayerClientSettingsType.java
@@ -2,6 +2,7 @@ package net.creeperhost.polylib.player.settings;
 
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.resources.Identifier;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.function.Supplier;
@@ -15,7 +16,7 @@ import java.util.function.Supplier;
  */
 public final class PlayerClientSettingsType<T>
 {
-    private final String id;
+    private final Identifier id;
     private final StreamCodec<RegistryFriendlyByteBuf, T> codec;
     private final Supplier<T> defaultFactory;
     private final BroadcastScope scope;
@@ -23,7 +24,7 @@ public final class PlayerClientSettingsType<T>
     /** Optional translation key for this type's human-readable display name. */
     @Nullable private final String displayNameKey;
 
-    PlayerClientSettingsType(String id,
+    PlayerClientSettingsType(Identifier id,
                              StreamCodec<RegistryFriendlyByteBuf, T> codec,
                              Supplier<T> defaultFactory,
                              BroadcastScope scope,
@@ -38,7 +39,7 @@ public final class PlayerClientSettingsType<T>
         this.displayNameKey = displayNameKey;
     }
 
-    public String id()
+    public Identifier id()
     {
         return id;
     }

--- a/common/src/main/java/net/creeperhost/polylib/player/settings/PlayerClientSettingsType.java
+++ b/common/src/main/java/net/creeperhost/polylib/player/settings/PlayerClientSettingsType.java
@@ -1,0 +1,83 @@
+package net.creeperhost.polylib.player.settings;
+
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.StreamCodec;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.function.Supplier;
+
+/**
+ * Typed token representing a registered PlayerClientSetting type.
+ * Create via {@link PlayerClientSettingsRegistry#register} and store as a
+ * {@code public static final} constant in your mod.
+ *
+ * @param <T> The value type
+ */
+public final class PlayerClientSettingsType<T>
+{
+    private final String id;
+    private final StreamCodec<RegistryFriendlyByteBuf, T> codec;
+    private final Supplier<T> defaultFactory;
+    private final BroadcastScope scope;
+    private final boolean copyOnDeath;
+    /** Optional translation key for this type's human-readable display name. */
+    @Nullable private final String displayNameKey;
+
+    PlayerClientSettingsType(String id,
+                             StreamCodec<RegistryFriendlyByteBuf, T> codec,
+                             Supplier<T> defaultFactory,
+                             BroadcastScope scope,
+                             boolean copyOnDeath,
+                             @Nullable String displayNameKey)
+    {
+        this.id = id;
+        this.codec = codec;
+        this.defaultFactory = defaultFactory;
+        this.scope = scope;
+        this.copyOnDeath = copyOnDeath;
+        this.displayNameKey = displayNameKey;
+    }
+
+    public String id()
+    {
+        return id;
+    }
+
+    public StreamCodec<RegistryFriendlyByteBuf, T> codec()
+    {
+        return codec;
+    }
+
+    public Supplier<T> defaultFactory()
+    {
+        return defaultFactory;
+    }
+
+    public BroadcastScope scope()
+    {
+        return scope;
+    }
+
+    public boolean copyOnDeath()
+    {
+        return copyOnDeath;
+    }
+
+    /**
+     * Optional translation key for this type's human-readable display name.
+     * Null if no display name was registered.
+     * Used by UI panels that list available settings types.
+     */
+    @Nullable
+    public String displayNameKey()
+    {
+        return displayNameKey;
+    }
+
+    @Override
+    public String toString()
+    {
+        return "PlayerClientSettingsType[" + id + "]";
+    }
+}
+

--- a/common/src/main/java/net/creeperhost/polylib/player/settings/UpdatePlayerClientSettingC2SPayload.java
+++ b/common/src/main/java/net/creeperhost/polylib/player/settings/UpdatePlayerClientSettingC2SPayload.java
@@ -1,0 +1,44 @@
+package net.creeperhost.polylib.player.settings;
+
+import io.netty.buffer.ByteBuf;
+import net.creeperhost.polylib.Constants;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.resources.Identifier;
+
+/**
+ * C2S: client sends an updated PlayerClientSetting value to the server.
+ */
+public record UpdatePlayerClientSettingC2SPayload(String typeId, byte[] data)
+        implements CustomPacketPayload
+{
+    public static final Type<UpdatePlayerClientSettingC2SPayload> TYPE = new Type<>(
+            Identifier.fromNamespaceAndPath(Constants.MOD_ID, "update_player_setting"));
+
+    public static final StreamCodec<ByteBuf, UpdatePlayerClientSettingC2SPayload> CODEC = StreamCodec.of(
+            (buf, payload) ->
+            {
+                byte[] idBytes = payload.typeId().getBytes(java.nio.charset.StandardCharsets.UTF_8);
+                buf.writeInt(idBytes.length);
+                buf.writeBytes(idBytes);
+                buf.writeInt(payload.data().length);
+                buf.writeBytes(payload.data());
+            },
+            buf ->
+            {
+                int idLen = buf.readInt();
+                byte[] idBytes = new byte[idLen];
+                buf.readBytes(idBytes);
+                String typeId = new String(idBytes, java.nio.charset.StandardCharsets.UTF_8);
+                int dataLen = buf.readInt();
+                byte[] data = new byte[dataLen];
+                buf.readBytes(data);
+                return new UpdatePlayerClientSettingC2SPayload(typeId, data);
+            });
+
+    @Override
+    public Type<? extends CustomPacketPayload> type()
+    {
+        return TYPE;
+    }
+}

--- a/common/src/main/java/net/creeperhost/polylib/player/settings/UpdatePlayerClientSettingC2SPayload.java
+++ b/common/src/main/java/net/creeperhost/polylib/player/settings/UpdatePlayerClientSettingC2SPayload.java
@@ -9,7 +9,7 @@ import net.minecraft.resources.Identifier;
 /**
  * C2S: client sends an updated PlayerClientSetting value to the server.
  */
-public record UpdatePlayerClientSettingC2SPayload(String typeId, byte[] data)
+public record UpdatePlayerClientSettingC2SPayload(Identifier typeId, byte[] data)
         implements CustomPacketPayload
 {
     public static final Type<UpdatePlayerClientSettingC2SPayload> TYPE = new Type<>(
@@ -18,7 +18,7 @@ public record UpdatePlayerClientSettingC2SPayload(String typeId, byte[] data)
     public static final StreamCodec<ByteBuf, UpdatePlayerClientSettingC2SPayload> CODEC = StreamCodec.of(
             (buf, payload) ->
             {
-                byte[] idBytes = payload.typeId().getBytes(java.nio.charset.StandardCharsets.UTF_8);
+                byte[] idBytes = payload.typeId().toString().getBytes(java.nio.charset.StandardCharsets.UTF_8);
                 buf.writeInt(idBytes.length);
                 buf.writeBytes(idBytes);
                 buf.writeInt(payload.data().length);
@@ -29,7 +29,7 @@ public record UpdatePlayerClientSettingC2SPayload(String typeId, byte[] data)
                 int idLen = buf.readInt();
                 byte[] idBytes = new byte[idLen];
                 buf.readBytes(idBytes);
-                String typeId = new String(idBytes, java.nio.charset.StandardCharsets.UTF_8);
+                Identifier typeId = Identifier.parse(new String(idBytes, java.nio.charset.StandardCharsets.UTF_8));
                 int dataLen = buf.readInt();
                 byte[] data = new byte[dataLen];
                 buf.readBytes(data);

--- a/fabric/src/main/java/net/creeperhost/polylib/FabricServerEvents.java
+++ b/fabric/src/main/java/net/creeperhost/polylib/FabricServerEvents.java
@@ -1,0 +1,37 @@
+package net.creeperhost.polylib;
+
+import net.creeperhost.polylib.accessibility.AccessibilityPrefsManager;
+import net.creeperhost.polylib.player.serverdata.PlayerServerDataManager;
+import net.creeperhost.polylib.player.settings.PlayerClientSettingsManager;
+import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents;
+import net.minecraft.server.level.ServerPlayer;
+
+import java.util.UUID;
+
+/**
+ * Fabric server-side lifecycle hooks for PolyLib player settings.
+ * Registered in {@link PolyLibFabric#onInitialize()}.
+ * Respawn/death copy is handled automatically by the {@code copyOnDeath()} flag on each AttachmentType.
+ */
+public final class FabricServerEvents
+{
+    private FabricServerEvents() {}
+
+    public static void register()
+    {
+        ServerPlayConnectionEvents.JOIN.register((handler, sender, server) ->
+        {
+            ServerPlayer player = handler.getPlayer();
+            PlayerClientSettingsManager.onPlayerLogin(player);
+            PlayerServerDataManager.onPlayerLogin(player);
+        });
+
+        ServerPlayConnectionEvents.DISCONNECT.register((handler, server) ->
+        {
+            UUID uuid = handler.getPlayer().getUUID();
+            AccessibilityPrefsManager.clearPlayer(uuid);
+            PlayerClientSettingsManager.onPlayerLogout(uuid);
+            PlayerServerDataManager.onPlayerLogout(uuid);
+        });
+    }
+}

--- a/fabric/src/main/java/net/creeperhost/polylib/FabricServerEvents.java
+++ b/fabric/src/main/java/net/creeperhost/polylib/FabricServerEvents.java
@@ -1,5 +1,6 @@
 package net.creeperhost.polylib;
 
+// TODO: depends on feat/accessibility PR being merged — AccessibilityPrefsManager lives there
 import net.creeperhost.polylib.accessibility.AccessibilityPrefsManager;
 import net.creeperhost.polylib.player.serverdata.PlayerServerDataManager;
 import net.creeperhost.polylib.player.settings.PlayerClientSettingsManager;

--- a/fabric/src/main/java/net/creeperhost/polylib/platform/FabricNetworkHelper.java
+++ b/fabric/src/main/java/net/creeperhost/polylib/platform/FabricNetworkHelper.java
@@ -1,9 +1,17 @@
 package net.creeperhost.polylib.platform;
 
 import io.netty.buffer.Unpooled;
+import net.creeperhost.polylib.accessibility.AccessibilityPrefsC2SPayload;
+import net.creeperhost.polylib.accessibility.AccessibilityPrefsManager;
 import net.creeperhost.polylib.network.PolyLibNetwork;
 import net.creeperhost.polylib.network.packets.*;
 import net.creeperhost.polylib.platform.services.INetworkHelper;
+import net.creeperhost.polylib.player.serverdata.PlayerServerDataClientCache;
+import net.creeperhost.polylib.player.serverdata.SyncPlayerServerDataS2CPayload;
+import net.creeperhost.polylib.player.settings.PlayerClientSettingsClientCache;
+import net.creeperhost.polylib.player.settings.PlayerClientSettingsManager;
+import net.creeperhost.polylib.player.settings.PlayerClientSettingSyncS2CPayload;
+import net.creeperhost.polylib.player.settings.UpdatePlayerClientSettingC2SPayload;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import net.fabricmc.fabric.api.networking.v1.PayloadTypeRegistry;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
@@ -22,9 +30,13 @@ public class FabricNetworkHelper implements INetworkHelper
     {
         PayloadTypeRegistry.clientboundPlay().register(ContainerClientPayload.TYPE, ContainerClientPayload.CODEC);
         PayloadTypeRegistry.clientboundPlay().register(TileDataClientPayload.TYPE, TileDataClientPayload.CODEC);
+        PayloadTypeRegistry.clientboundPlay().register(PlayerClientSettingSyncS2CPayload.TYPE, PlayerClientSettingSyncS2CPayload.CODEC);
+        PayloadTypeRegistry.clientboundPlay().register(SyncPlayerServerDataS2CPayload.TYPE, SyncPlayerServerDataS2CPayload.CODEC);
         PayloadTypeRegistry.serverboundPlay().register(ContainerServerPayload.TYPE, ContainerServerPayload.CODEC);
         PayloadTypeRegistry.serverboundPlay().register(TileDataServerPayload.TYPE, TileDataServerPayload.CODEC);
         PayloadTypeRegistry.serverboundPlay().register(TilePacketServerPayload.TYPE, TilePacketServerPayload.CODEC);
+        PayloadTypeRegistry.serverboundPlay().register(AccessibilityPrefsC2SPayload.TYPE, AccessibilityPrefsC2SPayload.CODEC);
+        PayloadTypeRegistry.serverboundPlay().register(UpdatePlayerClientSettingC2SPayload.TYPE, UpdatePlayerClientSettingC2SPayload.CODEC);
 
         ServerPlayNetworking.registerGlobalReceiver(ContainerServerPayload.TYPE, (payload, context) ->
         {
@@ -44,6 +56,15 @@ public class FabricNetworkHelper implements INetworkHelper
             RegistryFriendlyByteBuf buf = new RegistryFriendlyByteBuf(Unpooled.wrappedBuffer(payload.data()), player.registryAccess());
             context.server().execute(() -> PolyLibNetwork.handleTilePacketFromClient(player, buf));
         });
+        ServerPlayNetworking.registerGlobalReceiver(AccessibilityPrefsC2SPayload.TYPE, (payload, context) ->
+                context.server().execute(() -> AccessibilityPrefsManager.applyFromClient(
+                        context.player().getUUID(), payload.values())));
+        ServerPlayNetworking.registerGlobalReceiver(UpdatePlayerClientSettingC2SPayload.TYPE, (payload, context) ->
+        {
+            ServerPlayer sp = context.player();
+            context.server().execute(() ->
+                    PlayerClientSettingsManager.applyFromClient(sp, payload.typeId(), payload.data()));
+        });
     }
 
     @Override
@@ -61,6 +82,12 @@ public class FabricNetworkHelper implements INetworkHelper
             RegistryFriendlyByteBuf buf = new RegistryFriendlyByteBuf(Unpooled.wrappedBuffer(payload.data()), player.registryAccess());
             context.client().execute(() -> PolyLibNetwork.handleTileDataValueFromServer(player, buf));
         });
+        ClientPlayNetworking.registerGlobalReceiver(PlayerClientSettingSyncS2CPayload.TYPE, (payload, context) ->
+                context.client().execute(() ->
+                        PlayerClientSettingsClientCache.receive(payload.playerUUID(), payload.typeId(), payload.data())));
+        ClientPlayNetworking.registerGlobalReceiver(SyncPlayerServerDataS2CPayload.TYPE, (payload, context) ->
+                context.client().execute(() ->
+                        PlayerServerDataClientCache.receive(payload.typeId(), payload.data())));
     }
 
     @Override

--- a/fabric/src/main/java/net/creeperhost/polylib/platform/FabricNetworkHelper.java
+++ b/fabric/src/main/java/net/creeperhost/polylib/platform/FabricNetworkHelper.java
@@ -1,6 +1,7 @@
 package net.creeperhost.polylib.platform;
 
 import io.netty.buffer.Unpooled;
+// TODO: depends on feat/accessibility PR being merged - AccessibilityPrefs classes live there
 import net.creeperhost.polylib.accessibility.AccessibilityPrefsC2SPayload;
 import net.creeperhost.polylib.accessibility.AccessibilityPrefsManager;
 import net.creeperhost.polylib.network.PolyLibNetwork;

--- a/fabric/src/main/java/net/creeperhost/polylib/platform/FabricPlayerDataHelper.java
+++ b/fabric/src/main/java/net/creeperhost/polylib/platform/FabricPlayerDataHelper.java
@@ -1,0 +1,186 @@
+package net.creeperhost.polylib.platform;
+
+import com.mojang.serialization.Codec;
+import io.netty.buffer.Unpooled;
+import net.creeperhost.polylib.Constants;
+import net.creeperhost.polylib.platform.services.IPlayerDataHelper;
+import net.creeperhost.polylib.player.serverdata.PlayerServerDataRegistry;
+import net.creeperhost.polylib.player.serverdata.PlayerServerDataStore;
+import net.creeperhost.polylib.player.serverdata.PlayerServerDataType;
+import net.creeperhost.polylib.player.settings.PlayerClientSettingsStore;
+import net.creeperhost.polylib.player.settings.PlayerClientSettingsType;
+import net.fabricmc.fabric.api.attachment.v1.AttachmentRegistry;
+import net.fabricmc.fabric.api.attachment.v1.AttachmentType;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.resources.Identifier;
+import net.minecraft.server.level.ServerPlayer;
+
+import java.nio.ByteBuffer;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Fabric implementation of {@link IPlayerDataHelper}.
+ * Each {@link PlayerClientSettingsType} gets its own {@link AttachmentType AttachmentType&lt;byte[]&gt;}
+ * registered with {@link AttachmentRegistry}, persisted via {@code Codec.BYTE_BUFFER.xmap(...)}.
+ * The {@code copyOnDeath()} flag mirrors {@link PlayerClientSettingsType#copyOnDeath()}.
+ */
+public class FabricPlayerDataHelper implements IPlayerDataHelper
+{
+    /** Codec<byte[]> using DFU BYTE_BUFFER — compatible with DFU 9. */
+    private static final Codec<byte[]> BYTE_ARRAY_CODEC = Codec.BYTE_BUFFER.xmap(
+            buf -> {
+                if (buf.hasArray()) return buf.array();
+                byte[] bytes = new byte[buf.capacity()];
+                buf.get(bytes);
+                return bytes;
+            },
+            ByteBuffer::wrap);
+
+    private final Map<String, AttachmentType<byte[]>> attachmentsByTypeId = new LinkedHashMap<>();
+
+    @Override
+    public void registerType(PlayerClientSettingsType<?> type)
+    {
+        // Convert the namespaced type id (e.g. "discrafthonored:appearance") to a valid
+        // Identifier path by replacing ':' → '/' and any non-[a-z0-9_.-/] chars → '_'
+        String sanitized = type.id().replace(':', '/').replaceAll("[^a-z0-9_.\\-/]", "_");
+        Identifier id = Identifier.fromNamespaceAndPath(Constants.MOD_ID, "settings/" + sanitized);
+
+        AttachmentType<byte[]> attachment;
+        if (type.copyOnDeath())
+        {
+            attachment = AttachmentRegistry.create(id,
+                    builder -> builder.persistent(BYTE_ARRAY_CODEC).copyOnDeath());
+        }
+        else
+        {
+            attachment = AttachmentRegistry.create(id,
+                    builder -> builder.persistent(BYTE_ARRAY_CODEC));
+        }
+        attachmentsByTypeId.put(type.id(), attachment);
+    }
+
+    @Override
+    public void loadAll(UUID playerUUID, ServerPlayer player, PlayerClientSettingsStore store)
+    {
+        for (Map.Entry<String, AttachmentType<byte[]>> entry : attachmentsByTypeId.entrySet())
+        {
+            byte[] bytes = player.getAttached(entry.getValue());
+            if (bytes != null && bytes.length > 0)
+            {
+                PlayerClientSettingsType<?> type = net.creeperhost.polylib.player.settings.PlayerClientSettingsRegistry
+                        .byId(entry.getKey()).orElse(null);
+                if (type != null)
+                    loadTyped(type, bytes, player, store);
+            }
+        }
+    }
+
+    @Override
+    public void saveAll(UUID playerUUID, ServerPlayer player, PlayerClientSettingsStore store)
+    {
+        for (PlayerClientSettingsType<?> dirty : store.getDirty())
+        {
+            AttachmentType<byte[]> attachment = attachmentsByTypeId.get(dirty.id());
+            if (attachment != null)
+            {
+                byte[] bytes = encodeTyped(dirty, player, store);
+                player.setAttached(attachment, bytes);
+            }
+        }
+        store.clearDirty();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> void loadTyped(PlayerClientSettingsType<T> type,
+                                      byte[] bytes,
+                                      ServerPlayer player,
+                                      PlayerClientSettingsStore store)
+    {
+        RegistryFriendlyByteBuf buf = new RegistryFriendlyByteBuf(
+                Unpooled.wrappedBuffer(bytes),
+                player.level().registryAccess());
+        T value = type.codec().decode(buf);
+        store.load(type, value);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> byte[] encodeTyped(PlayerClientSettingsType<T> type,
+                                          ServerPlayer player,
+                                          PlayerClientSettingsStore store)
+    {
+        RegistryFriendlyByteBuf buf = new RegistryFriendlyByteBuf(
+                Unpooled.buffer(),
+                player.level().registryAccess());
+        type.codec().encode(buf, store.get(type));
+        byte[] data = new byte[buf.readableBytes()];
+        buf.readBytes(data);
+        buf.release();
+        return data;
+    }
+
+    private final Map<String, AttachmentType<?>> serverDataAttachments = new LinkedHashMap<>();
+
+    @Override
+    public void registerServerDataType(PlayerServerDataType<?> type)
+    {
+        String sanitized = type.id().replace(':', '/').replaceAll("[^a-z0-9_.\\-/]", "_");
+        Identifier id = Identifier.fromNamespaceAndPath(Constants.MOD_ID, "sdata/" + sanitized);
+        AttachmentType<?> attachment = createServerDataAttachment(type, id);
+        serverDataAttachments.put(type.id(), attachment);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> AttachmentType<T> createServerDataAttachment(PlayerServerDataType<T> type, Identifier id)
+    {
+        return type.copyOnDeath()
+                ? AttachmentRegistry.create(id, builder -> builder.persistent(type.nbtCodec()).copyOnDeath())
+                : AttachmentRegistry.create(id, builder -> builder.persistent(type.nbtCodec()));
+    }
+
+    @Override
+    public void loadServerData(UUID playerUUID, ServerPlayer player, PlayerServerDataStore store)
+    {
+        for (Map.Entry<String, AttachmentType<?>> entry : serverDataAttachments.entrySet())
+        {
+            loadServerDataTyped(entry.getKey(), entry.getValue(), player, store);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> void loadServerDataTyped(String id,
+                                                 AttachmentType<T> attachment,
+                                                 ServerPlayer player,
+                                                 PlayerServerDataStore store)
+    {
+        T value = player.getAttached(attachment);
+        if (value != null)
+        {
+            PlayerServerDataType<T> type = (PlayerServerDataType<T>) PlayerServerDataRegistry.byId(id).orElse(null);
+            if (type != null) store.load(type, value);
+        }
+    }
+
+    @Override
+    public void saveServerData(UUID playerUUID, ServerPlayer player, PlayerServerDataStore store)
+    {
+        for (PlayerServerDataType<?> dirty : store.getDirty())
+        {
+            saveServerDataTyped(dirty, player, store);
+        }
+        store.clearDirty();
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> void saveServerDataTyped(PlayerServerDataType<T> type,
+                                          ServerPlayer player,
+                                          PlayerServerDataStore store)
+    {
+        AttachmentType<T> attachment = (AttachmentType<T>) serverDataAttachments.get(type.id());
+        if (attachment != null)
+            player.setAttached(attachment, store.get(type));
+    }
+}
+

--- a/fabric/src/main/java/net/creeperhost/polylib/platform/FabricPlayerDataHelper.java
+++ b/fabric/src/main/java/net/creeperhost/polylib/platform/FabricPlayerDataHelper.java
@@ -38,15 +38,12 @@ public class FabricPlayerDataHelper implements IPlayerDataHelper
             },
             ByteBuffer::wrap);
 
-    private final Map<String, AttachmentType<byte[]>> attachmentsByTypeId = new LinkedHashMap<>();
+    private final Map<Identifier, AttachmentType<byte[]>> attachmentsByTypeId = new LinkedHashMap<>();
 
     @Override
     public void registerType(PlayerClientSettingsType<?> type)
     {
-        // Convert the namespaced type id (e.g. "discrafthonored:appearance") to a valid
-        // Identifier path by replacing ':' → '/' and any non-[a-z0-9_.-/] chars → '_'
-        String sanitized = type.id().replace(':', '/').replaceAll("[^a-z0-9_.\\-/]", "_");
-        Identifier id = Identifier.fromNamespaceAndPath(Constants.MOD_ID, "settings/" + sanitized);
+        Identifier id = Identifier.fromNamespaceAndPath(Constants.MOD_ID, "settings/" + type.id().getNamespace() + "/" + type.id().getPath());
 
         AttachmentType<byte[]> attachment;
         if (type.copyOnDeath())
@@ -65,7 +62,7 @@ public class FabricPlayerDataHelper implements IPlayerDataHelper
     @Override
     public void loadAll(UUID playerUUID, ServerPlayer player, PlayerClientSettingsStore store)
     {
-        for (Map.Entry<String, AttachmentType<byte[]>> entry : attachmentsByTypeId.entrySet())
+        for (Map.Entry<Identifier, AttachmentType<byte[]>> entry : attachmentsByTypeId.entrySet())
         {
             byte[] bytes = player.getAttached(entry.getValue());
             if (bytes != null && bytes.length > 0)
@@ -121,13 +118,12 @@ public class FabricPlayerDataHelper implements IPlayerDataHelper
         return data;
     }
 
-    private final Map<String, AttachmentType<?>> serverDataAttachments = new LinkedHashMap<>();
+    private final Map<Identifier, AttachmentType<?>> serverDataAttachments = new LinkedHashMap<>();
 
     @Override
     public void registerServerDataType(PlayerServerDataType<?> type)
     {
-        String sanitized = type.id().replace(':', '/').replaceAll("[^a-z0-9_.\\-/]", "_");
-        Identifier id = Identifier.fromNamespaceAndPath(Constants.MOD_ID, "sdata/" + sanitized);
+        Identifier id = Identifier.fromNamespaceAndPath(Constants.MOD_ID, "sdata/" + type.id().getNamespace() + "/" + type.id().getPath());
         AttachmentType<?> attachment = createServerDataAttachment(type, id);
         serverDataAttachments.put(type.id(), attachment);
     }
@@ -143,14 +139,14 @@ public class FabricPlayerDataHelper implements IPlayerDataHelper
     @Override
     public void loadServerData(UUID playerUUID, ServerPlayer player, PlayerServerDataStore store)
     {
-        for (Map.Entry<String, AttachmentType<?>> entry : serverDataAttachments.entrySet())
+        for (Map.Entry<Identifier, AttachmentType<?>> entry : serverDataAttachments.entrySet())
         {
             loadServerDataTyped(entry.getKey(), entry.getValue(), player, store);
         }
     }
 
     @SuppressWarnings("unchecked")
-    private static <T> void loadServerDataTyped(String id,
+    private static <T> void loadServerDataTyped(Identifier id,
                                                  AttachmentType<T> attachment,
                                                  ServerPlayer player,
                                                  PlayerServerDataStore store)

--- a/fabric/src/main/resources/META-INF/services/net.creeperhost.polylib.platform.services.IPlayerDataHelper
+++ b/fabric/src/main/resources/META-INF/services/net.creeperhost.polylib.platform.services.IPlayerDataHelper
@@ -1,0 +1,1 @@
+net.creeperhost.polylib.platform.FabricPlayerDataHelper

--- a/neoforge/src/main/java/net/creeperhost/polylib/NeoForgeEvents.java
+++ b/neoforge/src/main/java/net/creeperhost/polylib/NeoForgeEvents.java
@@ -1,0 +1,58 @@
+package net.creeperhost.polylib;
+
+import net.creeperhost.polylib.accessibility.AccessibilityPrefsManager;
+import net.creeperhost.polylib.player.serverdata.PlayerServerDataManager;
+import net.creeperhost.polylib.player.settings.PlayerClientSettingsManager;
+import net.minecraft.server.level.ServerPlayer;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.event.entity.player.PlayerEvent;
+
+import java.util.UUID;
+
+/**
+ * NeoForge server-side game-bus event handlers for PolyLib lifecycle hooks.
+ */
+@EventBusSubscriber(modid = Constants.MOD_ID)
+public class NeoForgeEvents
+{
+    @SubscribeEvent
+    public static void onPlayerLogin(PlayerEvent.PlayerLoggedInEvent event)
+    {
+        if (event.getEntity() instanceof ServerPlayer sp)
+        {
+            PlayerClientSettingsManager.onPlayerLogin(sp);
+            PlayerServerDataManager.onPlayerLogin(sp);
+        }
+    }
+
+    @SubscribeEvent
+    public static void onPlayerLogout(PlayerEvent.PlayerLoggedOutEvent event)
+    {
+        UUID uuid = event.getEntity().getUUID();
+        AccessibilityPrefsManager.clearPlayer(uuid);
+        PlayerClientSettingsManager.onPlayerLogout(uuid);
+        PlayerServerDataManager.onPlayerLogout(uuid);
+    }
+
+    @SubscribeEvent
+    public static void onPlayerRespawn(PlayerEvent.PlayerRespawnEvent event)
+    {
+        if (event.getEntity() instanceof ServerPlayer sp)
+        {
+            // UUID is stable across respawn in NeoForge — pass same UUID as both old and new
+            PlayerClientSettingsManager.onPlayerRespawn(sp.getUUID(), sp);
+            PlayerServerDataManager.onPlayerRespawn(sp.getUUID(), sp);
+        }
+    }
+
+    @SubscribeEvent
+    public static void onStartTracking(PlayerEvent.StartTracking event)
+    {
+        if (event.getTarget() instanceof ServerPlayer tracked
+                && event.getEntity() instanceof ServerPlayer tracker)
+        {
+            PlayerClientSettingsManager.syncTrackingRange(tracked, tracker);
+        }
+    }
+}

--- a/neoforge/src/main/java/net/creeperhost/polylib/platform/NeoForgeNetworkHelper.java
+++ b/neoforge/src/main/java/net/creeperhost/polylib/platform/NeoForgeNetworkHelper.java
@@ -2,9 +2,17 @@ package net.creeperhost.polylib.platform;
 
 import io.netty.buffer.Unpooled;
 import net.creeperhost.polylib.Constants;
+import net.creeperhost.polylib.accessibility.AccessibilityPrefsC2SPayload;
+import net.creeperhost.polylib.accessibility.AccessibilityPrefsManager;
 import net.creeperhost.polylib.network.PolyLibNetwork;
 import net.creeperhost.polylib.network.packets.*;
 import net.creeperhost.polylib.platform.services.INetworkHelper;
+import net.creeperhost.polylib.player.serverdata.PlayerServerDataClientCache;
+import net.creeperhost.polylib.player.serverdata.SyncPlayerServerDataS2CPayload;
+import net.creeperhost.polylib.player.settings.PlayerClientSettingsClientCache;
+import net.creeperhost.polylib.player.settings.PlayerClientSettingsManager;
+import net.creeperhost.polylib.player.settings.PlayerClientSettingSyncS2CPayload;
+import net.creeperhost.polylib.player.settings.UpdatePlayerClientSettingC2SPayload;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.minecraft.server.level.ServerPlayer;
@@ -54,6 +62,19 @@ public class NeoForgeNetworkHelper implements INetworkHelper
             Player player = ctx.player();
             RegistryFriendlyByteBuf buf = new RegistryFriendlyByteBuf(Unpooled.wrappedBuffer(payload.data()), player.registryAccess());
             ctx.enqueueWork(() -> PolyLibNetwork.handleTileDataValueFromServer(player, buf));
+        });
+        registrar.playToClient(PlayerClientSettingSyncS2CPayload.TYPE, PlayerClientSettingSyncS2CPayload.CODEC, (payload, ctx) ->
+                ctx.enqueueWork(() -> PlayerClientSettingsClientCache.receive(
+                        payload.playerUUID(), payload.typeId(), payload.data())));
+        registrar.playToClient(SyncPlayerServerDataS2CPayload.TYPE, SyncPlayerServerDataS2CPayload.CODEC, (payload, ctx) ->
+                ctx.enqueueWork(() -> PlayerServerDataClientCache.receive(payload.typeId(), payload.data())));
+        registrar.playToServer(AccessibilityPrefsC2SPayload.TYPE, AccessibilityPrefsC2SPayload.CODEC, (payload, ctx) ->
+                ctx.enqueueWork(() -> AccessibilityPrefsManager.applyFromClient(
+                        ((ServerPlayer) ctx.player()).getUUID(), payload.values())));
+        registrar.playToServer(UpdatePlayerClientSettingC2SPayload.TYPE, UpdatePlayerClientSettingC2SPayload.CODEC, (payload, ctx) ->
+        {
+            ServerPlayer sp = (ServerPlayer) ctx.player();
+            ctx.enqueueWork(() -> PlayerClientSettingsManager.applyFromClient(sp, payload.typeId(), payload.data()));
         });
     }
 

--- a/neoforge/src/main/java/net/creeperhost/polylib/platform/NeoForgePlayerDataHelper.java
+++ b/neoforge/src/main/java/net/creeperhost/polylib/platform/NeoForgePlayerDataHelper.java
@@ -1,0 +1,164 @@
+package net.creeperhost.polylib.platform;
+
+import io.netty.buffer.Unpooled;
+import net.creeperhost.polylib.platform.services.IPlayerDataHelper;
+import net.creeperhost.polylib.player.serverdata.PlayerServerDataRegistry;
+import net.creeperhost.polylib.player.serverdata.PlayerServerDataStore;
+import net.creeperhost.polylib.player.serverdata.PlayerServerDataType;
+import net.creeperhost.polylib.player.settings.PlayerClientSettingsStore;
+import net.creeperhost.polylib.player.settings.PlayerClientSettingsType;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.NbtOps;
+import net.minecraft.nbt.Tag;
+import net.minecraft.nbt.ByteArrayTag;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.server.level.ServerPlayer;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * NeoForge implementation of {@link IPlayerDataHelper}.
+ *
+ * <p><b>Client settings</b> (StreamCodec-based): stored as {@code byte[]} in
+ * {@code player.getPersistentData()} under key {@code polylib_settings.<typeId>}.
+ *
+ * <p><b>Server data</b> (DFU Codec-based): stored as a wrapped NBT tag in
+ * {@code player.getPersistentData()} under key {@code polylib_sdata.<typeId>}.
+ * The tag is wrapped in a CompoundTag ({@code {v: <tag>}}) to handle all NBT element types.
+ *
+ * <p>Both are saved with the player NBT automatically and loaded on join.
+ */
+public class NeoForgePlayerDataHelper implements IPlayerDataHelper
+{
+    private final Map<String, PlayerClientSettingsType<?>> registeredTypes = new LinkedHashMap<>();
+    private static final String SETTINGS_PREFIX = "polylib_settings.";
+
+    @Override
+    public void registerType(PlayerClientSettingsType<?> type)
+    {
+        registeredTypes.put(type.id(), type);
+    }
+
+    @Override
+    public void loadAll(UUID playerUUID, ServerPlayer player, PlayerClientSettingsStore store)
+    {
+        CompoundTag persistent = player.getPersistentData();
+        for (PlayerClientSettingsType<?> type : registeredTypes.values())
+        {
+            String key = SETTINGS_PREFIX + type.id();
+            if (persistent.contains(key))
+            {
+                byte[] bytes = persistent.getByteArray(key).orElse(null);
+                if (bytes == null || bytes.length == 0) continue;
+                loadClientTyped(type, bytes, player, store);
+            }
+        }
+    }
+
+    @Override
+    public void saveAll(UUID playerUUID, ServerPlayer player, PlayerClientSettingsStore store)
+    {
+        CompoundTag persistent = player.getPersistentData();
+        for (PlayerClientSettingsType<?> dirty : store.getDirty())
+        {
+            String key = SETTINGS_PREFIX + dirty.id();
+            byte[] bytes = encodeClientTyped(dirty, player, store);
+            persistent.put(key, new ByteArrayTag(bytes));
+        }
+        store.clearDirty();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> void loadClientTyped(PlayerClientSettingsType<T> type,
+                                             byte[] bytes,
+                                             ServerPlayer player,
+                                             PlayerClientSettingsStore store)
+    {
+        RegistryFriendlyByteBuf buf = new RegistryFriendlyByteBuf(
+                Unpooled.wrappedBuffer(bytes),
+                player.level().registryAccess());
+        T value = type.codec().decode(buf);
+        store.load(type, value);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> byte[] encodeClientTyped(PlayerClientSettingsType<T> type,
+                                                 ServerPlayer player,
+                                                 PlayerClientSettingsStore store)
+    {
+        RegistryFriendlyByteBuf buf = new RegistryFriendlyByteBuf(
+                Unpooled.buffer(),
+                player.level().registryAccess());
+        type.codec().encode(buf, store.get(type));
+        byte[] data = new byte[buf.readableBytes()];
+        buf.readBytes(data);
+        buf.release();
+        return data;
+    }
+
+    private final Map<String, PlayerServerDataType<?>> registeredServerTypes = new LinkedHashMap<>();
+    private static final String SDATA_PREFIX = "polylib_sdata.";
+
+    @Override
+    public void registerServerDataType(PlayerServerDataType<?> type)
+    {
+        registeredServerTypes.put(type.id(), type);
+    }
+
+    @Override
+    public void loadServerData(UUID playerUUID, ServerPlayer player, PlayerServerDataStore store)
+    {
+        CompoundTag persistent = player.getPersistentData();
+        for (PlayerServerDataType<?> type : registeredServerTypes.values())
+        {
+            String key = SDATA_PREFIX + type.id();
+            Tag raw = persistent.get(key);
+            if (raw instanceof CompoundTag wrapper)
+            {
+                Tag inner = wrapper.get("v");
+                if (inner != null)
+                    loadServerTyped(type, inner, store);
+            }
+        }
+    }
+
+    @Override
+    public void saveServerData(UUID playerUUID, ServerPlayer player, PlayerServerDataStore store)
+    {
+        CompoundTag persistent = player.getPersistentData();
+        for (PlayerServerDataType<?> dirty : store.getDirty())
+        {
+            String key = SDATA_PREFIX + dirty.id();
+            saveServerTyped(dirty, persistent, key, store);
+        }
+        store.clearDirty();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> void loadServerTyped(PlayerServerDataType<T> type,
+                                             Tag inner,
+                                             PlayerServerDataStore store)
+    {
+        type.nbtCodec().parse(NbtOps.INSTANCE, inner)
+                .result()
+                .ifPresent(value -> store.load(type, value));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> void saveServerTyped(PlayerServerDataType<T> type,
+                                             CompoundTag persistent,
+                                             String key,
+                                             PlayerServerDataStore store)
+    {
+        type.nbtCodec().encodeStart(NbtOps.INSTANCE, store.get(type))
+                .result()
+                .ifPresent(tag -> {
+                    CompoundTag wrapper = new CompoundTag();
+                    wrapper.put("v", tag);
+                    persistent.put(key, wrapper);
+                });
+    }
+}
+

--- a/neoforge/src/main/java/net/creeperhost/polylib/platform/NeoForgePlayerDataHelper.java
+++ b/neoforge/src/main/java/net/creeperhost/polylib/platform/NeoForgePlayerDataHelper.java
@@ -12,6 +12,7 @@ import net.minecraft.nbt.NbtOps;
 import net.minecraft.nbt.Tag;
 import net.minecraft.nbt.ByteArrayTag;
 import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.resources.Identifier;
 import net.minecraft.server.level.ServerPlayer;
 
 import java.util.LinkedHashMap;
@@ -32,7 +33,7 @@ import java.util.UUID;
  */
 public class NeoForgePlayerDataHelper implements IPlayerDataHelper
 {
-    private final Map<String, PlayerClientSettingsType<?>> registeredTypes = new LinkedHashMap<>();
+    private final Map<Identifier, PlayerClientSettingsType<?>> registeredTypes = new LinkedHashMap<>();
     private static final String SETTINGS_PREFIX = "polylib_settings.";
 
     @Override
@@ -47,7 +48,7 @@ public class NeoForgePlayerDataHelper implements IPlayerDataHelper
         CompoundTag persistent = player.getPersistentData();
         for (PlayerClientSettingsType<?> type : registeredTypes.values())
         {
-            String key = SETTINGS_PREFIX + type.id();
+            String key = SETTINGS_PREFIX + type.id().toString();
             if (persistent.contains(key))
             {
                 byte[] bytes = persistent.getByteArray(key).orElse(null);
@@ -63,7 +64,7 @@ public class NeoForgePlayerDataHelper implements IPlayerDataHelper
         CompoundTag persistent = player.getPersistentData();
         for (PlayerClientSettingsType<?> dirty : store.getDirty())
         {
-            String key = SETTINGS_PREFIX + dirty.id();
+            String key = SETTINGS_PREFIX + dirty.id().toString();
             byte[] bytes = encodeClientTyped(dirty, player, store);
             persistent.put(key, new ByteArrayTag(bytes));
         }
@@ -98,7 +99,7 @@ public class NeoForgePlayerDataHelper implements IPlayerDataHelper
         return data;
     }
 
-    private final Map<String, PlayerServerDataType<?>> registeredServerTypes = new LinkedHashMap<>();
+    private final Map<Identifier, PlayerServerDataType<?>> registeredServerTypes = new LinkedHashMap<>();
     private static final String SDATA_PREFIX = "polylib_sdata.";
 
     @Override
@@ -113,7 +114,7 @@ public class NeoForgePlayerDataHelper implements IPlayerDataHelper
         CompoundTag persistent = player.getPersistentData();
         for (PlayerServerDataType<?> type : registeredServerTypes.values())
         {
-            String key = SDATA_PREFIX + type.id();
+            String key = SDATA_PREFIX + type.id().toString();
             Tag raw = persistent.get(key);
             if (raw instanceof CompoundTag wrapper)
             {
@@ -130,7 +131,7 @@ public class NeoForgePlayerDataHelper implements IPlayerDataHelper
         CompoundTag persistent = player.getPersistentData();
         for (PlayerServerDataType<?> dirty : store.getDirty())
         {
-            String key = SDATA_PREFIX + dirty.id();
+            String key = SDATA_PREFIX + dirty.id().toString();
             saveServerTyped(dirty, persistent, key, store);
         }
         store.clearDirty();

--- a/neoforge/src/main/resources/META-INF/services/net.creeperhost.polylib.platform.services.IPlayerDataHelper
+++ b/neoforge/src/main/resources/META-INF/services/net.creeperhost.polylib.platform.services.IPlayerDataHelper
@@ -1,0 +1,1 @@
+net.creeperhost.polylib.platform.NeoForgePlayerDataHelper


### PR DESCRIPTION
Adds two complementary player data systems with full multiloader support.

### PlayerClientSettings (client-authoritative, server-synced)
Player preferences that live on the client and are synced to the server on login. The server can broadcast them to other players based on `BroadcastScope` (SELF_ONLY, ALL_ONLINE, TRACKING_RANGE, SERVER_ONLY).
- `PlayerClientSettingsType<T>` — typed token with codec, default factory, scope, copyOnDeath flag
- `PlayerClientSettingsRegistry` — registration with optional lang datagen
- `PlayerClientSettingsManager` — server-side manager, handles login/logout/respawn/C2S
- `PlayerClientSettingsStore` — per-player in-memory store with dirty tracking
- `PlayerClientSettingsClientCache` — client-side cache of received S2C data
- `PlayerClientSettingSyncS2CPayload` / `UpdatePlayerClientSettingC2SPayload` — network payloads

### PlayerServerData (server-authoritative, optional S2C sync)
Server-side persistent data attached to players, saved/loaded on login/logout/respawn.
- `PlayerServerDataType<T>` — typed token with nbt codec + optional sync codec
- `PlayerServerDataRegistry`, `PlayerServerDataManager`, `PlayerServerDataStore`
- `SyncPlayerServerDataS2CPayload` / `PlayerServerDataClientCache`

### Platform implementations
- Fabric: `AttachmentRegistry` for both systems
- NeoForge: `player.getPersistentData()` CompoundTag with `polylib_settings.<id>` / `polylib_sdata.<id>` keys
- `IPlayerDataHelper` service interface + `Services.PLAYER_DATA` entry point
- Event hooks: `FabricServerEvents`, `NeoForgeEvents`
- All payloads registered in both network helpers