### PR TITLE
feat: add AccessibilityOptionsRegistry with server policy and client override support

### DIFF
--- a/common/src/main/java/net/creeperhost/polylib/accessibility/AccessibilityOptionsRegistry.java
+++ b/common/src/main/java/net/creeperhost/polylib/accessibility/AccessibilityOptionsRegistry.java
@@ -1,0 +1,138 @@
+package net.creeperhost.polylib.accessibility;
+
+import net.creeperhost.polylib.PolylibCommon;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.gui.screens.options.AccessibilityOptionsScreen;
+
+import java.util.*;
+
+/**
+ * Central registry for accessibility option widgets that PolyLib injects into the vanilla
+ * Accessibility Options screen.
+ * <p>
+ * Mods register providers during client init. PolyLib's event handlers call
+ * {@link #inject(Screen)} on every screen init event.
+ *
+ * <h3>Usage example</h3>
+ * <pre>{@code
+ * // During client init:
+ * AccessibilityOptionsRegistry.register("mymod.rescue", target -> {
+ *     target.addCategory(Component.literal("My Mod"));
+ *     target.addToggle(Component.literal("Fall Rescue"), prefs::isRescueOn, prefs::setRescueOn);
+ * });
+ * }</pre>
+ */
+public final class AccessibilityOptionsRegistry
+{
+    private AccessibilityOptionsRegistry() {}
+
+    private record Entry(String key, AccessibilityPolicy policy, OptionsWidgetProvider provider) {}
+
+    private static final List<Entry> ENTRIES = new ArrayList<>();
+
+    /**
+     * Registers a widget provider with the default policy ({@link AccessibilityPolicy#PLAYER_OVERRIDES_SERVER}).
+     *
+     * @param key      Unique namespaced key, e.g. {@code "discrafthonored.rescue"}
+     * @param provider Callback that adds widgets to the options list
+     */
+    public static void register(String key, OptionsWidgetProvider provider)
+    {
+        register(key, AccessibilityPolicy.PLAYER_OVERRIDES_SERVER, provider);
+    }
+
+    /**
+     * Registers a widget provider with an explicit policy.
+     *
+     * @param key      Unique namespaced key
+     * @param policy   Whether the player's value overrides server config
+     * @param provider Callback that adds widgets to the options list
+     */
+    public static void register(String key, AccessibilityPolicy policy, OptionsWidgetProvider provider)
+    {
+        ENTRIES.add(new Entry(key, policy, provider));
+    }
+
+    /**
+     * Builder-style overload — registers toggles/pairs/categories via a fluent
+     * {@link AccessibilityRegistrationBuilder} and simultaneously captures default English
+     * strings for lang datagen.
+     *
+     * @param key     Unique namespaced key, e.g. {@code "mymod.rescue"}
+     * @param builder Consumer that configures the {@link AccessibilityRegistrationBuilder}
+     */
+    public static void register(String key, java.util.function.Consumer<AccessibilityRegistrationBuilder> builder)
+    {
+        register(key, AccessibilityPolicy.PLAYER_OVERRIDES_SERVER, builder);
+    }
+
+    /**
+     * Builder-style registration with an explicit policy.
+     *
+     * @param key     Unique namespaced key
+     * @param policy  Whether the player's value overrides server config
+     * @param builder Consumer that configures the {@link AccessibilityRegistrationBuilder}
+     */
+    public static void register(String key, AccessibilityPolicy policy,
+                                java.util.function.Consumer<AccessibilityRegistrationBuilder> builder)
+    {
+        AccessibilityRegistrationBuilder b = new AccessibilityRegistrationBuilder();
+        builder.accept(b);
+        ENTRIES.add(new Entry(key, policy, b));
+    }
+
+    /**
+     * Called from the loader's screen init event. Injects all registered widgets when the
+     * screen is {@link AccessibilityOptionsScreen}.
+     */
+    public static void inject(Screen screen)
+    {
+        if (!(screen instanceof AccessibilityOptionsScreen accessibilityScreen)) return;
+
+        OptionsListTarget target = OptionsListTarget.from(accessibilityScreen);
+        if (target == null) return;
+
+        for (Entry entry : ENTRIES)
+        {
+            entry.provider().addOptions(target);
+        }
+    }
+
+    /**
+     * Returns the effective policy for the given key, taking into account
+     * {@code PolyConfig.radicalAccessibility}.
+     * <p>
+     * When {@code radicalAccessibility} is enabled, all entries are treated as
+     * {@link AccessibilityPolicy#PLAYER_OVERRIDES_SERVER} regardless of registration.
+     */
+    public static AccessibilityPolicy effectivePolicy(String key)
+    {
+        if (PolylibCommon.configData != null && PolylibCommon.configData.radicalAccessibility)
+        {
+            return AccessibilityPolicy.PLAYER_OVERRIDES_SERVER;
+        }
+        for (Entry e : ENTRIES)
+        {
+            if (e.key().equals(key)) return e.policy();
+        }
+        return AccessibilityPolicy.PLAYER_OVERRIDES_SERVER;
+    }
+
+    /**
+     * Returns all registered keys whose effective policy is {@link AccessibilityPolicy#PLAYER_OVERRIDES_SERVER}.
+     * Used by the server-side handler to decide which preference values to accept unconditionally.
+     */
+    public static Set<String> getServerSyncedKeys()
+    {
+        Set<String> keys = new LinkedHashSet<>();
+        boolean radical = PolylibCommon.configData != null && PolylibCommon.configData.radicalAccessibility;
+        for (Entry e : ENTRIES)
+        {
+            if (radical || e.policy() == AccessibilityPolicy.PLAYER_OVERRIDES_SERVER)
+            {
+                keys.add(e.key());
+            }
+        }
+        return keys;
+    }
+}

--- a/common/src/main/java/net/creeperhost/polylib/accessibility/AccessibilityPolicy.java
+++ b/common/src/main/java/net/creeperhost/polylib/accessibility/AccessibilityPolicy.java
@@ -1,0 +1,23 @@
+package net.creeperhost.polylib.accessibility;
+
+/**
+ * Controls how a registered accessibility preference interacts with server configuration.
+ */
+public enum AccessibilityPolicy
+{
+    /**
+     * Default. The player's value is stored and applied server-side regardless of any server
+     * configuration. Use this for gameplay-safety toggles (fall rescue, void grave, etc.) where
+     * overriding the player's choice would be harmful.
+     */
+    PLAYER_OVERRIDES_SERVER,
+
+    /**
+     * Server configuration may clamp or override the player's preference at runtime.
+     * Use for purely cosmetic or input-mode toggles.
+     * <p>
+     * This policy can be upgraded to {@link #PLAYER_OVERRIDES_SERVER} at runtime by setting
+     * {@code radicalAccessibility = true} in {@code polylib.json5}.
+     */
+    RESPECTS_SERVER_CONFIG
+}

--- a/common/src/main/java/net/creeperhost/polylib/accessibility/AccessibilityPrefsC2SPayload.java
+++ b/common/src/main/java/net/creeperhost/polylib/accessibility/AccessibilityPrefsC2SPayload.java
@@ -1,0 +1,52 @@
+package net.creeperhost.polylib.accessibility;
+
+import io.netty.buffer.ByteBuf;
+import net.creeperhost.polylib.Constants;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.resources.Identifier;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * C2S packet: client sends its current accessibility preference values to the server.
+ * Only preferences with effective policy {@link AccessibilityPolicy#PLAYER_OVERRIDES_SERVER}
+ * are included.
+ */
+public record AccessibilityPrefsC2SPayload(Map<String, Boolean> values) implements CustomPacketPayload
+{
+    public static final Type<AccessibilityPrefsC2SPayload> TYPE = new Type<>(
+            Identifier.fromNamespaceAndPath(Constants.MOD_ID, "accessibility_prefs"));
+
+    public static final StreamCodec<ByteBuf, AccessibilityPrefsC2SPayload> CODEC = StreamCodec.of(
+            (buf, payload) -> {
+                buf.writeInt(payload.values().size());
+                payload.values().forEach((key, value) -> {
+                    byte[] keyBytes = key.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+                    buf.writeInt(keyBytes.length);
+                    buf.writeBytes(keyBytes);
+                    buf.writeBoolean(value);
+                });
+            },
+            buf -> {
+                int size = buf.readInt();
+                Map<String, Boolean> map = new HashMap<>(size);
+                for (int i = 0; i < size; i++)
+                {
+                    int keyLen = buf.readInt();
+                    byte[] keyBytes = new byte[keyLen];
+                    buf.readBytes(keyBytes);
+                    String key = new String(keyBytes, java.nio.charset.StandardCharsets.UTF_8);
+                    boolean value = buf.readBoolean();
+                    map.put(key, value);
+                }
+                return new AccessibilityPrefsC2SPayload(map);
+            });
+
+    @Override
+    public Type<? extends CustomPacketPayload> type()
+    {
+        return TYPE;
+    }
+}

--- a/common/src/main/java/net/creeperhost/polylib/accessibility/AccessibilityPrefsManager.java
+++ b/common/src/main/java/net/creeperhost/polylib/accessibility/AccessibilityPrefsManager.java
@@ -1,0 +1,70 @@
+package net.creeperhost.polylib.accessibility;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Server-side store for per-player accessibility preferences.
+ * <p>
+ * Pure common — no loader API. Thread-safe via {@link ConcurrentHashMap}.
+ * Values are stored exactly as received from the client; no server config gate is applied here.
+ * The policy check ({@link AccessibilityPolicy}) is enforced on the client before sending.
+ */
+public final class AccessibilityPrefsManager
+{
+    private AccessibilityPrefsManager() {}
+
+    private static final ConcurrentHashMap<UUID, Map<String, Boolean>> STORE = new ConcurrentHashMap<>();
+
+    /**
+     * Applies a batch of preference values from a client packet.
+     * Overwrites only the provided keys; other keys are left unchanged.
+     *
+     * @param playerUUID UUID of the player who sent the packet
+     * @param values     Map of preference key → value as sent by the client
+     */
+    public static void applyFromClient(UUID playerUUID, Map<String, Boolean> values)
+    {
+        STORE.computeIfAbsent(playerUUID, id -> new ConcurrentHashMap<>()).putAll(values);
+    }
+
+    /**
+     * Sets a single preference value directly (e.g. from a server-side command or admin tool).
+     */
+    public static void set(UUID playerUUID, String key, boolean value)
+    {
+        STORE.computeIfAbsent(playerUUID, id -> new ConcurrentHashMap<>()).put(key, value);
+    }
+
+    /**
+     * Returns the player's current value for the given key, or {@code defaultValue} if
+     * no value has been stored (player hasn't sent prefs yet, or has since logged out).
+     */
+    public static boolean getOrDefault(UUID playerUUID, String key, boolean defaultValue)
+    {
+        Map<String, Boolean> prefs = STORE.get(playerUUID);
+        if (prefs == null) return defaultValue;
+        return prefs.getOrDefault(key, defaultValue);
+    }
+
+    /**
+     * Returns the player's current value for the given key, or empty if not set.
+     */
+    public static Optional<Boolean> get(UUID playerUUID, String key)
+    {
+        Map<String, Boolean> prefs = STORE.get(playerUUID);
+        if (prefs == null) return Optional.empty();
+        Boolean v = prefs.get(key);
+        return Optional.ofNullable(v);
+    }
+
+
+    /**
+     * Removes all stored preferences for the given player.
+     * Call this from the player logout event to avoid memory leaks.
+     */
+    public static void clearPlayer(UUID playerUUID)
+    {
+        STORE.remove(playerUUID);
+    }
+}

--- a/common/src/main/java/net/creeperhost/polylib/accessibility/AccessibilityRegistrationBuilder.java
+++ b/common/src/main/java/net/creeperhost/polylib/accessibility/AccessibilityRegistrationBuilder.java
@@ -1,0 +1,82 @@
+package net.creeperhost.polylib.accessibility;
+
+import net.creeperhost.polylib.data.lang.PolyLangContributions;
+import net.minecraft.network.chat.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.BooleanSupplier;
+
+/**
+ * Fluent builder for registering accessibility options while simultaneously contributing
+ * their default English translations to PolyLib's lang datagen system.
+ *
+ * <p>Used with the builder-style {@link AccessibilityOptionsRegistry#register} overloads:
+ * <pre>{@code
+ * AccessibilityOptionsRegistry.register("mymod.rescue", builder -> builder
+ *     .togglePair(
+ *         "mymod.accessibility.rescue_blink",    "Save Me: Blink",
+ *         () -> prefs.blinkRescueOn, v -> prefs.blinkRescueOn = v,
+ *         "mymod.accessibility.rescue_farreach", "Save Me: Far Reach",
+ *         () -> prefs.farReachOn, v -> prefs.farReachOn = v
+ *     )
+ *     .toggle(
+ *         "mymod.accessibility.void_grave", "Void Grave",
+ *         () -> prefs.voidGraveOn, v -> prefs.voidGraveOn = v
+ *     )
+ * );
+ * }</pre>
+ *
+ * <p>Each method contributes the given key+English pair to {@link PolyLangContributions}
+ * and stores the corresponding widget action. The builder itself implements
+ * {@link OptionsWidgetProvider} and is stored as the entry's provider.
+ */
+public final class AccessibilityRegistrationBuilder implements OptionsWidgetProvider
+{
+    private final List<Consumer<OptionsListTarget>> actions = new ArrayList<>();
+
+    AccessibilityRegistrationBuilder() {}
+
+    /** Adds a single toggle button. Contributes {@code key → defaultEnglish} to lang datagen. */
+    public AccessibilityRegistrationBuilder toggle(String key, String defaultEnglish,
+                                                   BooleanSupplier getter, Consumer<Boolean> setter)
+    {
+        PolyLangContributions.contribute(key, defaultEnglish);
+        Component label = Component.translatable(key);
+        actions.add(target -> target.addToggle(label, getter, setter));
+        return this;
+    }
+
+    /** Adds two toggle buttons side by side. Contributes both keys to lang datagen. */
+    public AccessibilityRegistrationBuilder togglePair(
+            String leftKey,  String leftEnglish,  BooleanSupplier leftGetter,  Consumer<Boolean> leftSetter,
+            String rightKey, String rightEnglish, BooleanSupplier rightGetter, Consumer<Boolean> rightSetter)
+    {
+        PolyLangContributions.contribute(leftKey,  leftEnglish);
+        PolyLangContributions.contribute(rightKey, rightEnglish);
+        Component leftLabel  = Component.translatable(leftKey);
+        Component rightLabel = Component.translatable(rightKey);
+        actions.add(target -> target.addTogglePair(leftLabel, leftGetter, leftSetter,
+                                                   rightLabel, rightGetter, rightSetter));
+        return this;
+    }
+
+    /** Adds a non-interactive section header. Contributes {@code key → defaultEnglish} to lang datagen. */
+    public AccessibilityRegistrationBuilder category(String key, String defaultEnglish)
+    {
+        PolyLangContributions.contribute(key, defaultEnglish);
+        Component title = Component.translatable(key);
+        actions.add(target -> target.addCategory(title));
+        return this;
+    }
+
+    @Override
+    public void addOptions(OptionsListTarget target)
+    {
+        for (Consumer<OptionsListTarget> action : actions)
+        {
+            action.accept(target);
+        }
+    }
+}

--- a/common/src/main/java/net/creeperhost/polylib/accessibility/OptionsListTarget.java
+++ b/common/src/main/java/net/creeperhost/polylib/accessibility/OptionsListTarget.java
@@ -1,0 +1,167 @@
+package net.creeperhost.polylib.accessibility;
+
+import net.creeperhost.polylib.Constants;
+import net.minecraft.client.gui.components.AbstractWidget;
+import net.minecraft.client.gui.components.CycleButton;
+import net.minecraft.client.gui.components.OptionsList;
+import net.minecraft.network.chat.Component;
+import org.jetbrains.annotations.Nullable;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.function.BooleanSupplier;
+import java.util.function.Consumer;
+
+/**
+ * Wraps a reflected {@link OptionsList} and exposes a concise builder API for adding widgets
+ * to the Accessibility Options screen.
+ * <p>
+ * Uses reflection to call the NeoForge-patched {@code addSmall(AbstractWidget, AbstractWidget)}
+ * and {@code addBig(AbstractWidget)} overloads which are not present in the vanilla compile target.
+ */
+public final class OptionsListTarget
+{
+    private static Field optionsListField = null;
+    private static boolean fieldReflectionAttempted = false;
+    private static Method addSmallMethod = null;
+    private static Method addBigMethod = null;
+    private static boolean methodReflectionAttempted = false;
+
+    private final OptionsList optionsList;
+
+    OptionsListTarget(OptionsList optionsList)
+    {
+        this.optionsList = optionsList;
+        ensureMethodsReflected();
+    }
+
+
+    /** Adds two small (half-width) widgets side by side. Right may be null for a single entry. */
+    public void addSmall(AbstractWidget left, @Nullable AbstractWidget right)
+    {
+        if (addSmallMethod != null)
+        {
+            try
+            {
+                addSmallMethod.invoke(optionsList, left, right);
+            }
+            catch (Exception e)
+            {
+                Constants.LOG.debug("[PolyLib/AccessibilityOptions] addSmall reflection failed: {}", e.getMessage());
+            }
+        }
+    }
+
+    /** Adds a single full-width widget. */
+    public void addBig(AbstractWidget widget)
+    {
+        if (addBigMethod != null)
+        {
+            try
+            {
+                addBigMethod.invoke(optionsList, widget);
+            }
+            catch (Exception e)
+            {
+                Constants.LOG.debug("[PolyLib/AccessibilityOptions] addBig reflection failed: {}", e.getMessage());
+            }
+        }
+    }
+
+    /** Adds a toggle (On/Off) button. */
+    public CycleButton<Boolean> addToggle(Component label, BooleanSupplier getter, Consumer<Boolean> setter)
+    {
+        CycleButton<Boolean> btn = CycleButton.onOffBuilder(getter.getAsBoolean())
+                .create(0, 0, 150, 20, label, (button, value) -> setter.accept(value));
+        addSmall(btn, null);
+        return btn;
+    }
+
+    public void addTogglePair(Component leftLabel, BooleanSupplier leftGetter, Consumer<Boolean> leftSetter,
+                              Component rightLabel, BooleanSupplier rightGetter, Consumer<Boolean> rightSetter)
+    {
+        CycleButton<Boolean> left = CycleButton.onOffBuilder(leftGetter.getAsBoolean())
+                .create(0, 0, 150, 20, leftLabel, (btn, val) -> leftSetter.accept(val));
+        CycleButton<Boolean> right = CycleButton.onOffBuilder(rightGetter.getAsBoolean())
+                .create(0, 0, 150, 20, rightLabel, (btn, val) -> rightSetter.accept(val));
+        addSmall(left, right);
+    }
+
+    public void addCategory(Component title)
+    {
+        net.minecraft.client.gui.components.Button header =
+                net.minecraft.client.gui.components.Button.builder(title, b -> {})
+                        .size(310, 20)
+                        .build();
+        header.active = false;
+        addBig(header);
+    }
+
+
+    /**
+     * Reflects the {@link OptionsList} field from the given Accessibility Options screen.
+     * Returns null (and logs once) if reflection fails.
+     */
+    @Nullable
+    static OptionsListTarget from(net.minecraft.client.gui.screens.options.AccessibilityOptionsScreen screen)
+    {
+        if (!fieldReflectionAttempted)
+        {
+            fieldReflectionAttempted = true;
+            try
+            {
+                for (Field f : net.minecraft.client.gui.screens.options.OptionsSubScreen.class.getDeclaredFields())
+                {
+                    if (f.getType() == OptionsList.class)
+                    {
+                        f.setAccessible(true);
+                        optionsListField = f;
+                        break;
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                Constants.LOG.warn("[PolyLib/AccessibilityOptions] Failed to reflect OptionsList field: {}", e.getMessage());
+            }
+        }
+
+        if (optionsListField == null) return null;
+
+        try
+        {
+            OptionsList list = (OptionsList) optionsListField.get(screen);
+            return list != null ? new OptionsListTarget(list) : null;
+        }
+        catch (Exception e)
+        {
+            Constants.LOG.debug("[PolyLib/AccessibilityOptions] Failed to get OptionsList instance: {}", e.getMessage());
+            return null;
+        }
+    }
+
+    private static void ensureMethodsReflected()
+    {
+        if (methodReflectionAttempted) return;
+        methodReflectionAttempted = true;
+        try
+        {
+            // NeoForge patches OptionsList to accept AbstractWidget directly.
+            // This overload does not exist in vanilla — reflection lets us call it
+            // without a compile-time dependency on NeoForge's patched classes.
+            addSmallMethod = OptionsList.class.getMethod("addSmall", AbstractWidget.class, AbstractWidget.class);
+        }
+        catch (NoSuchMethodException e)
+        {
+            Constants.LOG.debug("[PolyLib/AccessibilityOptions] addSmall(AbstractWidget, AbstractWidget) not found — running on vanilla/Fabric?");
+        }
+        try
+        {
+            addBigMethod = OptionsList.class.getMethod("addBig", AbstractWidget.class);
+        }
+        catch (NoSuchMethodException e)
+        {
+            Constants.LOG.debug("[PolyLib/AccessibilityOptions] addBig(AbstractWidget) not found — running on vanilla/Fabric?");
+        }
+    }
+}

--- a/common/src/main/java/net/creeperhost/polylib/accessibility/OptionsWidgetProvider.java
+++ b/common/src/main/java/net/creeperhost/polylib/accessibility/OptionsWidgetProvider.java
@@ -1,0 +1,11 @@
+package net.creeperhost.polylib.accessibility;
+
+/**
+ * Callback that adds one or more widgets to the Accessibility Options screen via
+ * {@link OptionsListTarget}.
+ */
+@FunctionalInterface
+public interface OptionsWidgetProvider
+{
+    void addOptions(OptionsListTarget target);
+}

--- a/common/src/main/java/net/creeperhost/polylib/config/PolyConfig.java
+++ b/common/src/main/java/net/creeperhost/polylib/config/PolyConfig.java
@@ -10,4 +10,7 @@ public class PolyConfig extends ConfigData {
     @Comment ("Allows poly lib to run as a server side only support. Without this, non-vanilla clients without polylib may not be able to connect.")
     public boolean serverOnlySupport = true;
 
+    @Comment ("When true, all registered accessibility preferences treat the player's value as authoritative, ignoring server policy.")
+    public boolean radicalAccessibility = false;
+
 }


### PR DESCRIPTION
Adds a system for injecting accessibility option widgets into the vanilla Accessibility Options screen, with server policy support and optional client override.

- **`AccessibilityOptionsRegistry`**: central registry. Mods call `register(key, provider)` or use the builder API. `inject(screen)` is called from `ScreenEvent.Init.Post` / Fabric's screen init callback.
- **`AccessibilityRegistrationBuilder`**: fluent builder for registering `toggle`, `togglePair`, and `category` widgets. Simultaneously contributes lang keys to `PolyLangContributions`.
- **`OptionsWidgetProvider`**: functional interface for producing `AbstractWidget` instances into an `OptionsList`.
- **`OptionsListTarget`**: reflection-based wrapper exposing `addSmall`/`addBig`/`addToggle`/`addTogglePair`/`addCategory` without compile-time NeoForge dep.
- **`AccessibilityPolicy`**: enum controlling whether server or client wins (`SERVER_WINS`, `CLIENT_WINS`, `RADICAL` — the last respects `PolyConfig.radicalAccessibility`).
- **`AccessibilityPrefsManager`**: server-side `ConcurrentHashMap` store for per-player prefs received from `AccessibilityPrefsC2SPayload`.
- `PolyConfig.radicalAccessibility` flag: when true, all registered preferences treat the player's value as authoritative.