### PR TITLE
feat: add ConfigPanelRegistry with ModMenu integration and optional keybind shortcuts

### DIFF
--- a/common/src/main/java/net/creeperhost/polylib/client/config/ConfigPanelRegistry.java
+++ b/common/src/main/java/net/creeperhost/polylib/client/config/ConfigPanelRegistry.java
@@ -183,6 +183,7 @@ public final class ConfigPanelRegistry
     public static void tickKeybinds()
     {
         Minecraft mc = Minecraft.getInstance();
+        if (mc == null) return;
         if (mc.screen != null) return;
 
         for (ConfigPanelEntry entry : ENTRIES.values())

--- a/common/src/main/java/net/creeperhost/polylib/client/config/ConfigPanelRegistry.java
+++ b/common/src/main/java/net/creeperhost/polylib/client/config/ConfigPanelRegistry.java
@@ -1,0 +1,250 @@
+package net.creeperhost.polylib.client.config;
+
+import com.mojang.blaze3d.platform.InputConstants;
+import net.creeperhost.polylib.Constants;
+import net.creeperhost.polylib.PolylibCommon;
+import net.creeperhost.polylib.client.modulargui.ModularGui;
+import net.creeperhost.polylib.client.modulargui.ModularGuiInjector;
+import net.creeperhost.polylib.client.modulargui.ModularGuiScreen;
+import net.creeperhost.polylib.client.modulargui.lib.GuiProvider;
+import net.minecraft.client.KeyMapping;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.network.chat.Component;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.*;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+/**
+ * Central registry for mod config panel screens.
+ *
+ * <h3>Registration tiers</h3>
+ * <ol>
+ *   <li><b>Vanilla Screen</b> — {@link #register(String, ScreenFactory)}.
+ *       Works on any loader. The dev provides a standard {@link Screen} factory.</li>
+ *   <li><b>ModularGui</b> — {@link #registerModularGui(String, GuiProviderFactory)}.
+ *       PolyLib wraps the {@link GuiProvider} in a {@link ModularGuiScreen} automatically.</li>
+ *   <li><b>ModularGui Injection</b> — {@link #registerInjection(String, Predicate, Function)}.
+ *       Overlays a ModularGui directly onto an existing vanilla screen via
+ *       {@link ModularGuiInjector}. Use for advanced cases only.</li>
+ * </ol>
+ *
+ * <h3>Auto-hooks</h3>
+ * <ul>
+ *   <li><b>NeoForge</b> — use {@code NeoForgeConfigHelper.register(...)} from the NeoForge
+ *       module. This calls both this registry AND {@code IConfigScreenFactory} so the entry
+ *       appears under the native "Mods → Config" button.</li>
+ *   <li><b>Fabric / Mod Menu</b> — handled automatically via PolyLib's {@code ModMenuCompat}
+ *       entrypoint when Mod Menu is present. Just call {@link #register} from the Fabric init.</li>
+ *   <li><b>Button injection fallback</b> — PolyLib injects a button into
+ *       {@code ConfigurationSectionScreen} and similar screens that the native hook doesn't cover.
+ *       Keybinds are also ticked via {@link #tickKeybinds()}.</li>
+ * </ul>
+ *
+ * <h3>PolyConfig json5 backing</h3>
+ * The per-mod keybind enable/disable map is stored in {@code polylib.json5} and managed
+ * through {@link PolylibCommon#configData}.
+ */
+public final class ConfigPanelRegistry
+{
+    private ConfigPanelRegistry() {}
+
+    public sealed interface ConfigPanelEntry permits VanillaEntry, ModularEntry
+    {
+        String modId();
+
+        /** Label shown on the injected config button. Defaults to a translatable key. */
+        Component label();
+
+        @Nullable
+        KeyMapping keyMapping();
+
+        Screen createScreen(Screen parent);
+    }
+
+    public record VanillaEntry(String modId, Component label, ScreenFactory factory, @Nullable KeyMapping keyMapping)
+            implements ConfigPanelEntry
+    {
+        @Override
+        public Screen createScreen(Screen parent)
+        {
+            return factory.create(parent);
+        }
+    }
+
+    public record ModularEntry(String modId, Component label, GuiProviderFactory factory, @Nullable KeyMapping keyMapping)
+            implements ConfigPanelEntry
+    {
+        @Override
+        public Screen createScreen(Screen parent)
+        {
+            return new ModularGuiScreen(factory.create(parent), parent);
+        }
+    }
+
+    private static final LinkedHashMap<String, ConfigPanelEntry> ENTRIES = new LinkedHashMap<>();
+
+    public static void register(String modId, ScreenFactory factory)
+    {
+        register(modId, defaultLabel(modId), factory, null);
+    }
+
+    public static void register(String modId, ScreenFactory factory, @Nullable KeyboardShortcut shortcut)
+    {
+        register(modId, defaultLabel(modId), factory, shortcut);
+    }
+
+    /** Register with a custom button label (e.g. {@code Component.translatable("mymod.config.appearance")}). */
+    public static void register(String modId, Component label, ScreenFactory factory, @Nullable KeyboardShortcut shortcut)
+    {
+        KeyMapping km = buildKeyMapping(modId, shortcut);
+        ENTRIES.put(modId, new VanillaEntry(modId, label, factory, km));
+    }
+
+    /**
+     * Register with a translation key and default English label.
+     * Contributes {@code labelKey → defaultEnglish} to {@link net.creeperhost.polylib.data.lang.PolyLangContributions} for lang datagen.
+     *
+     * @param modId          Mod ID
+     * @param labelKey       Translation key for the config button label
+     * @param defaultEnglish Default English text shown on the button
+     * @param factory        Screen factory
+     * @param shortcut       Optional keybind shortcut (may be null)
+     */
+    public static void register(String modId, String labelKey, String defaultEnglish,
+                                ScreenFactory factory, @Nullable KeyboardShortcut shortcut)
+    {
+        net.creeperhost.polylib.data.lang.PolyLangContributions.contribute(labelKey, defaultEnglish);
+        register(modId, Component.translatable(labelKey), factory, shortcut);
+    }
+
+
+    public static void registerModularGui(String modId, GuiProviderFactory factory)
+    {
+        registerModularGui(modId, defaultLabel(modId), factory, null);
+    }
+
+    public static void registerModularGui(String modId, GuiProviderFactory factory, @Nullable KeyboardShortcut shortcut)
+    {
+        registerModularGui(modId, defaultLabel(modId), factory, shortcut);
+    }
+
+    /** Register with a custom button label. */
+    public static void registerModularGui(String modId, Component label, GuiProviderFactory factory, @Nullable KeyboardShortcut shortcut)
+    {
+        KeyMapping km = buildKeyMapping(modId, shortcut);
+        ENTRIES.put(modId, new ModularEntry(modId, label, factory, km));
+    }
+
+    /**
+     * Register a ModularGui screen with a translation key and default English label.
+     * Contributes {@code labelKey → defaultEnglish} to {@link net.creeperhost.polylib.data.lang.PolyLangContributions} for lang datagen.
+     *
+     * @param modId          Mod ID
+     * @param labelKey       Translation key for the config button label
+     * @param defaultEnglish Default English text shown on the button
+     * @param factory        ModularGui provider factory
+     * @param shortcut       Optional keybind shortcut (may be null)
+     */
+    public static void registerModularGui(String modId, String labelKey, String defaultEnglish,
+                                          GuiProviderFactory factory, @Nullable KeyboardShortcut shortcut)
+    {
+        net.creeperhost.polylib.data.lang.PolyLangContributions.contribute(labelKey, defaultEnglish);
+        registerModularGui(modId, Component.translatable(labelKey), factory, shortcut);
+    }
+
+    /**
+     * Registers a ModularGui overlay that is injected directly into a matching vanilla screen
+     * rather than opening as a separate screen. Delegates to {@link ModularGuiInjector}.
+     * Does NOT appear in Mod Menu or native NeoForge config screen list.
+     */
+    public static void registerInjection(String modId, Predicate<Screen> screenPredicate,
+                                         Function<Screen, GuiProvider> guiFunction)
+    {
+        // ModularGuiInjector is common code — safe to call here
+        ModularGuiInjector.registerInjection(screenPredicate, s -> guiFunction.apply(s));
+    }
+
+
+    public static Map<String, ConfigPanelEntry> getAll()
+    {
+        return Collections.unmodifiableMap(ENTRIES);
+    }
+
+    @Nullable
+    public static ConfigPanelEntry get(String modId)
+    {
+        return ENTRIES.get(modId);
+    }
+
+    /**
+     * Checks all registered keybinds and opens the config screen when one is consumed.
+     * Only fires when no other screen is open.
+     */
+    public static void tickKeybinds()
+    {
+        Minecraft mc = Minecraft.getInstance();
+        if (mc.screen != null) return;
+
+        for (ConfigPanelEntry entry : ENTRIES.values())
+        {
+            KeyMapping km = entry.keyMapping();
+            if (km == null) continue;
+            if (!isKeybindEnabled(entry.modId())) continue;
+            while (km.consumeClick())
+            {
+                mc.setScreen(entry.createScreen(null));
+            }
+        }
+    }
+
+    /**
+     * Returns all registered {@link KeyMapping}s for loader key-registration events.
+     */
+    public static List<KeyMapping> getAllKeyMappings()
+    {
+        List<KeyMapping> list = new ArrayList<>();
+        for (ConfigPanelEntry entry : ENTRIES.values())
+        {
+            if (entry.keyMapping() != null) list.add(entry.keyMapping());
+        }
+        return list;
+    }
+
+
+    private static Component defaultLabel(String modId)
+    {
+        return Component.translatable(modId + ".polylib.config_button");
+    }
+
+    @Nullable
+    private static KeyMapping buildKeyMapping(String modId, @Nullable KeyboardShortcut shortcut)
+    {
+        if (shortcut == null) return null;
+
+        // Check if the user has disabled this keybind in polylib.json5
+        if (!isKeybindEnabled(modId)) return null;
+
+        // Auto-add to PolyConfig so it appears in the file the first time
+        if (PolylibCommon.configData != null
+                && !PolylibCommon.configData.configPanelKeybinds.containsKey(modId))
+        {
+            PolylibCommon.configData.configPanelKeybinds.put(modId, true);
+            if (PolylibCommon.configBuilder != null)
+            {
+                PolylibCommon.configBuilder.save(PolylibCommon.configData);
+            }
+        }
+
+        return shortcut.toKeyMapping("key." + modId + ".config_panel");
+    }
+
+    private static boolean isKeybindEnabled(String modId)
+    {
+        if (PolylibCommon.configData == null) return true;
+        return PolylibCommon.configData.configPanelKeybinds.getOrDefault(modId, true);
+    }
+}

--- a/common/src/main/java/net/creeperhost/polylib/client/config/ConfigPanelRegistry.java
+++ b/common/src/main/java/net/creeperhost/polylib/client/config/ConfigPanelRegistry.java
@@ -21,7 +21,7 @@ import java.util.function.Predicate;
 /**
  * Central registry for mod config panel screens.
  *
- * <h3>Registration tiers</h3>
+ * <h2>Registration tiers</h2>
  * <ol>
  *   <li><b>Vanilla Screen</b> — {@link #register(String, ScreenFactory)}.
  *       Works on any loader. The dev provides a standard {@link Screen} factory.</li>
@@ -32,7 +32,7 @@ import java.util.function.Predicate;
  *       {@link ModularGuiInjector}. Use for advanced cases only.</li>
  * </ol>
  *
- * <h3>Auto-hooks</h3>
+ * <h2>Auto-hooks</h2>
  * <ul>
  *   <li><b>NeoForge</b> — use {@code NeoForgeConfigHelper.register(...)} from the NeoForge
  *       module. This calls both this registry AND {@code IConfigScreenFactory} so the entry
@@ -44,7 +44,7 @@ import java.util.function.Predicate;
  *       Keybinds are also ticked via {@link #tickKeybinds()}.</li>
  * </ul>
  *
- * <h3>PolyConfig json5 backing</h3>
+ * <h2>PolyConfig json5 backing</h2>
  * The per-mod keybind enable/disable map is stored in {@code polylib.json5} and managed
  * through {@link PolylibCommon#configData}.
  */
@@ -106,7 +106,6 @@ public final class ConfigPanelRegistry
 
     /**
      * Register with a translation key and default English label.
-     * Contributes {@code labelKey → defaultEnglish} to {@link net.creeperhost.polylib.data.lang.PolyLangContributions} for lang datagen.
      *
      * @param modId          Mod ID
      * @param labelKey       Translation key for the config button label
@@ -117,7 +116,6 @@ public final class ConfigPanelRegistry
     public static void register(String modId, String labelKey, String defaultEnglish,
                                 ScreenFactory factory, @Nullable KeyboardShortcut shortcut)
     {
-        net.creeperhost.polylib.data.lang.PolyLangContributions.contribute(labelKey, defaultEnglish);
         register(modId, Component.translatable(labelKey), factory, shortcut);
     }
 
@@ -141,7 +139,6 @@ public final class ConfigPanelRegistry
 
     /**
      * Register a ModularGui screen with a translation key and default English label.
-     * Contributes {@code labelKey → defaultEnglish} to {@link net.creeperhost.polylib.data.lang.PolyLangContributions} for lang datagen.
      *
      * @param modId          Mod ID
      * @param labelKey       Translation key for the config button label
@@ -152,7 +149,6 @@ public final class ConfigPanelRegistry
     public static void registerModularGui(String modId, String labelKey, String defaultEnglish,
                                           GuiProviderFactory factory, @Nullable KeyboardShortcut shortcut)
     {
-        net.creeperhost.polylib.data.lang.PolyLangContributions.contribute(labelKey, defaultEnglish);
         registerModularGui(modId, Component.translatable(labelKey), factory, shortcut);
     }
 

--- a/common/src/main/java/net/creeperhost/polylib/client/config/GuiProviderFactory.java
+++ b/common/src/main/java/net/creeperhost/polylib/client/config/GuiProviderFactory.java
@@ -1,0 +1,14 @@
+package net.creeperhost.polylib.client.config;
+
+import net.creeperhost.polylib.client.modulargui.lib.GuiProvider;
+import net.minecraft.client.gui.screens.Screen;
+
+/**
+ * Factory that creates a PolyLib {@link GuiProvider} for a given parent screen.
+ * PolyLib wraps this in {@link net.creeperhost.polylib.client.modulargui.ModularGuiScreen} automatically.
+ */
+@FunctionalInterface
+public interface GuiProviderFactory
+{
+    GuiProvider create(Screen parent);
+}

--- a/common/src/main/java/net/creeperhost/polylib/client/config/KeyboardShortcut.java
+++ b/common/src/main/java/net/creeperhost/polylib/client/config/KeyboardShortcut.java
@@ -7,7 +7,7 @@ import net.minecraft.resources.Identifier;
 /**
  * Describes an optional keyboard shortcut for a config panel entry.
  *
- * <h3>Variants</h3>
+ * <h2>Variants</h2>
  * <ul>
  *   <li>{@link #unbound(KeyMapping.Category)} — shows in Controls but has no default key</li>
  *   <li>{@link #suggested(int, InputConstants.Type, KeyMapping.Category)} — has a suggested

--- a/common/src/main/java/net/creeperhost/polylib/client/config/KeyboardShortcut.java
+++ b/common/src/main/java/net/creeperhost/polylib/client/config/KeyboardShortcut.java
@@ -1,0 +1,64 @@
+package net.creeperhost.polylib.client.config;
+
+import com.mojang.blaze3d.platform.InputConstants;
+import net.minecraft.client.KeyMapping;
+import net.minecraft.resources.Identifier;
+
+/**
+ * Describes an optional keyboard shortcut for a config panel entry.
+ *
+ * <h3>Variants</h3>
+ * <ul>
+ *   <li>{@link #unbound(KeyMapping.Category)} — shows in Controls but has no default key</li>
+ *   <li>{@link #suggested(int, InputConstants.Type, KeyMapping.Category)} — has a suggested
+ *       key but defaults to UNBOUND so it never conflicts</li>
+ *   <li>{@link #bound(int, InputConstants.Type, KeyMapping.Category)} — bound by default;
+ *       use sparingly</li>
+ * </ul>
+ *
+ * <p>Create or reuse a {@link KeyMapping.Category} via
+ * {@code KeyMapping.Category.register(Identifier.fromNamespaceAndPath(modId, "main"))}.</p>
+ */
+public record KeyboardShortcut(int defaultKey, InputConstants.Type inputType, KeyMapping.Category keyCategory, boolean suggestedOnly)
+{
+    /**
+     * Unbound by default — appears in Controls with no assigned key.
+     */
+    public static KeyboardShortcut unbound(KeyMapping.Category category)
+    {
+        return new KeyboardShortcut(InputConstants.UNKNOWN.getValue(), InputConstants.Type.KEYSYM, category, false);
+    }
+
+    /**
+     * Has a suggested default key, but ships as UNBOUND so it never conflicts with other mods.
+     *
+     * @param key      GLFW key constant, e.g. {@code GLFW.GLFW_KEY_F6}
+     * @param type     Usually {@link InputConstants.Type#KEYSYM}
+     * @param category The Controls category to group this keybind under
+     */
+    public static KeyboardShortcut suggested(int key, InputConstants.Type type, KeyMapping.Category category)
+    {
+        return new KeyboardShortcut(key, type, category, true);
+    }
+
+    /**
+     * Bound by default. Prefer {@link #suggested} to avoid consuming user key space.
+     */
+    public static KeyboardShortcut bound(int key, InputConstants.Type type, KeyMapping.Category category)
+    {
+        return new KeyboardShortcut(key, type, category, false);
+    }
+
+    /**
+     * Creates a {@link KeyMapping} for this shortcut with the given description key.
+     * Suggested-only shortcuts are created with {@link InputConstants#UNKNOWN} as the default.
+     *
+     * @param descriptionKey Translation key for the keybind, e.g. {@code "key.mymod.config_panel"}
+     */
+    public KeyMapping toKeyMapping(String descriptionKey)
+    {
+        int actualDefault = suggestedOnly ? InputConstants.UNKNOWN.getValue() : defaultKey;
+        return new KeyMapping(descriptionKey, inputType, actualDefault, keyCategory);
+    }
+}
+

--- a/common/src/main/java/net/creeperhost/polylib/client/config/ScreenFactory.java
+++ b/common/src/main/java/net/creeperhost/polylib/client/config/ScreenFactory.java
@@ -1,0 +1,13 @@
+package net.creeperhost.polylib.client.config;
+
+import net.minecraft.client.gui.screens.Screen;
+
+/**
+ * Factory that creates a config {@link Screen} for a given parent screen.
+ * Used by {@link ConfigPanelRegistry} to open a mod's config panel.
+ */
+@FunctionalInterface
+public interface ScreenFactory
+{
+    Screen create(Screen parent);
+}

--- a/common/src/main/java/net/creeperhost/polylib/config/PolyConfig.java
+++ b/common/src/main/java/net/creeperhost/polylib/config/PolyConfig.java
@@ -13,4 +13,7 @@ public class PolyConfig extends ConfigData {
     @Comment ("When true, all registered accessibility preferences treat the player's value as authoritative, ignoring server policy.")
     public boolean radicalAccessibility = false;
 
+    @Comment ("Controls whether the keyboard shortcut for each registered config panel is enabled. Keys are mod IDs.")
+    public java.util.Map<String, Boolean> configPanelKeybinds = new java.util.HashMap<>();
+
 }

--- a/fabric/src/main/java/net/creeperhost/polylib/ModMenuCompat.java
+++ b/fabric/src/main/java/net/creeperhost/polylib/ModMenuCompat.java
@@ -1,0 +1,27 @@
+package net.creeperhost.polylib;
+
+import com.terraformersmc.modmenu.api.ConfigScreenFactory;
+import com.terraformersmc.modmenu.api.ModMenuApi;
+import net.creeperhost.polylib.client.config.ConfigPanelRegistry;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Mod Menu entrypoint. Loaded only when Mod Menu is present (declared as a {@code suggests}
+ * dependency, not a hard {@code depends}).
+ * <p>
+ * Reads from {@link ConfigPanelRegistry} — any mod that registered its config panel via
+ * PolyLib automatically appears in Mod Menu without any additional work.
+ */
+public class ModMenuCompat implements ModMenuApi
+{
+    @Override
+    public Map<String, ConfigScreenFactory<?>> getProvidedConfigScreenFactories()
+    {
+        Map<String, ConfigScreenFactory<?>> out = new LinkedHashMap<>();
+        ConfigPanelRegistry.getAll().forEach((modId, entry) ->
+                out.put(modId, parent -> entry.createScreen(parent)));
+        return out;
+    }
+}

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -17,6 +17,9 @@
     "entrypoints": {
         "main": [
           "net.creeperhost.polylib.PolyLibFabric"
+        ],
+        "modmenu": [
+          "net.creeperhost.polylib.ModMenuCompat"
         ]
     },
     "mixins": [
@@ -30,7 +33,7 @@
         "java": ">=${java_version}"
     },
     "suggests": {
-        "another-mod": "*"
+        "modmenu": "*"
     }
 }
   

--- a/neoforge/src/main/java/net/creeperhost/polylib/NeoForgeClientEvents.java
+++ b/neoforge/src/main/java/net/creeperhost/polylib/NeoForgeClientEvents.java
@@ -1,35 +1,22 @@
 package net.creeperhost.polylib;
 
-import net.creeperhost.polylib.accessibility.AccessibilityOptionsRegistry;
-import net.creeperhost.polylib.client.config.ConfigPanelRegistry;
 import net.creeperhost.polylib.client.modulargui.ModularGuiInjector;
-import net.creeperhost.polylib.player.serverdata.PlayerServerDataClientCache;
-import net.creeperhost.polylib.player.settings.PlayerClientSettingsClientCache;
+import net.creeperhost.polylib.client.config.ConfigPanelRegistry;
 import net.minecraft.client.Minecraft;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.EventPriority;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.client.event.ClientTickEvent;
-import net.neoforged.neoforge.client.event.ClientPlayerNetworkEvent;
 import net.neoforged.neoforge.client.event.ScreenEvent;
 
 @EventBusSubscriber(modid = Constants.MOD_ID, value = Dist.CLIENT)
 public class NeoForgeClientEvents
 {
-    @SubscribeEvent
-    public static void onClientLogout(ClientPlayerNetworkEvent.LoggingOut event)
-    {
-        PlayerClientSettingsClientCache.clear();
-        PlayerServerDataClientCache.clear();
-    }
-
     @SubscribeEvent(priority = EventPriority.HIGH)
     public static void eventInitScreenEvent(ScreenEvent.Init.Post event)
     {
         ModularGuiInjector.initPost(event.getScreen());
-        AccessibilityOptionsRegistry.inject(event.getScreen());
-        ConfigPanelRegistry.injectConfigButton(event.getScreen(), event::addListener);
     }
 
     @SubscribeEvent(priority = EventPriority.HIGH)

--- a/neoforge/src/main/java/net/creeperhost/polylib/NeoForgeClientEvents.java
+++ b/neoforge/src/main/java/net/creeperhost/polylib/NeoForgeClientEvents.java
@@ -1,27 +1,42 @@
 package net.creeperhost.polylib;
 
+import net.creeperhost.polylib.accessibility.AccessibilityOptionsRegistry;
+import net.creeperhost.polylib.client.config.ConfigPanelRegistry;
 import net.creeperhost.polylib.client.modulargui.ModularGuiInjector;
+import net.creeperhost.polylib.player.serverdata.PlayerServerDataClientCache;
+import net.creeperhost.polylib.player.settings.PlayerClientSettingsClientCache;
 import net.minecraft.client.Minecraft;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.EventPriority;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.client.event.ClientTickEvent;
+import net.neoforged.neoforge.client.event.ClientPlayerNetworkEvent;
 import net.neoforged.neoforge.client.event.ScreenEvent;
 
 @EventBusSubscriber(modid = Constants.MOD_ID, value = Dist.CLIENT)
 public class NeoForgeClientEvents
 {
+    @SubscribeEvent
+    public static void onClientLogout(ClientPlayerNetworkEvent.LoggingOut event)
+    {
+        PlayerClientSettingsClientCache.clear();
+        PlayerServerDataClientCache.clear();
+    }
+
     @SubscribeEvent(priority = EventPriority.HIGH)
     public static void eventInitScreenEvent(ScreenEvent.Init.Post event)
     {
         ModularGuiInjector.initPost(event.getScreen());
+        AccessibilityOptionsRegistry.inject(event.getScreen());
+        ConfigPanelRegistry.injectConfigButton(event.getScreen(), event::addListener);
     }
 
     @SubscribeEvent(priority = EventPriority.HIGH)
     public static void event(ClientTickEvent.Post event)
     {
         ModularGuiInjector.tick(Minecraft.getInstance());
+        ConfigPanelRegistry.tickKeybinds();
     }
 
     @SubscribeEvent(priority = EventPriority.HIGH)

--- a/neoforge/src/main/java/net/creeperhost/polylib/config/NeoForgeConfigHelper.java
+++ b/neoforge/src/main/java/net/creeperhost/polylib/config/NeoForgeConfigHelper.java
@@ -19,7 +19,7 @@ import org.jetbrains.annotations.Nullable;
  *       the native "Mods → Config" button without any extra boilerplate</li>
  * </ol>
  *
- * <h3>Usage (NeoForge mod constructor)</h3>
+ * <h2>Usage (NeoForge mod constructor)</h2>
  * <pre>{@code
  * public MyMod(ModContainer container, IEventBus bus) {
  *     // Vanilla Screen variant:

--- a/neoforge/src/main/java/net/creeperhost/polylib/config/NeoForgeConfigHelper.java
+++ b/neoforge/src/main/java/net/creeperhost/polylib/config/NeoForgeConfigHelper.java
@@ -1,0 +1,61 @@
+package net.creeperhost.polylib.config;
+
+import net.creeperhost.polylib.client.config.ConfigPanelRegistry;
+import net.creeperhost.polylib.client.config.GuiProviderFactory;
+import net.creeperhost.polylib.client.config.KeyboardShortcut;
+import net.creeperhost.polylib.client.config.ScreenFactory;
+import net.creeperhost.polylib.client.modulargui.ModularGuiScreen;
+import net.neoforged.fml.ModContainer;
+import net.neoforged.neoforge.client.gui.IConfigScreenFactory;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * NeoForge-specific helper for registering a mod config screen with PolyLib.
+ *
+ * <p>A single call to one of these methods registers the screen with both:
+ * <ol>
+ *   <li>{@link ConfigPanelRegistry} — powers PolyLib's keybind, button injection, and Fabric Mod Menu</li>
+ *   <li>NeoForge's {@link IConfigScreenFactory} extension point — makes the screen appear under
+ *       the native "Mods → Config" button without any extra boilerplate</li>
+ * </ol>
+ *
+ * <h3>Usage (NeoForge mod constructor)</h3>
+ * <pre>{@code
+ * public MyMod(ModContainer container, IEventBus bus) {
+ *     // Vanilla Screen variant:
+ *     NeoForgeConfigHelper.register(container, parent -> new MyConfigScreen(container, parent));
+ *
+ *     // ModularGui variant:
+ *     NeoForgeConfigHelper.registerModularGui(container, parent -> new MyConfigLayout(container, parent));
+ * }
+ * }</pre>
+ */
+public final class NeoForgeConfigHelper
+{
+    private NeoForgeConfigHelper() {}
+
+    public static void register(ModContainer container, ScreenFactory factory)
+    {
+        register(container, factory, null);
+    }
+
+    public static void register(ModContainer container, ScreenFactory factory, @Nullable KeyboardShortcut shortcut)
+    {
+        ConfigPanelRegistry.register(container.getModId(), factory, shortcut);
+        container.registerExtensionPoint(IConfigScreenFactory.class,
+                (mc, parent) -> factory.create(parent));
+    }
+
+    public static void registerModularGui(ModContainer container, GuiProviderFactory factory)
+    {
+        registerModularGui(container, factory, null);
+    }
+
+    public static void registerModularGui(ModContainer container, GuiProviderFactory factory,
+                                          @Nullable KeyboardShortcut shortcut)
+    {
+        ConfigPanelRegistry.registerModularGui(container.getModId(), factory, shortcut);
+        container.registerExtensionPoint(IConfigScreenFactory.class,
+                (mc, parent) -> new ModularGuiScreen(factory.create(parent), parent));
+    }
+}


### PR DESCRIPTION
Adds a central registry for mod config panel screens, with ModMenu integration on Fabric and optional keyboard shortcuts on both loaders.

- **`ConfigPanelRegistry`** (`common/client`): three registration tiers — vanilla `Screen`, `ModularGui`, and `ModularGui` injection overlay. Handles keybind ticking via `tickKeybinds()`.
- **`KeyboardShortcut`** / **`ScreenFactory`** / **`GuiProviderFactory`**: supporting interfaces/records.
- **`ModMenuCompat`** (`fabric`): `ModMenuApi` entrypoint. Reads `ConfigPanelRegistry` — any mod that registered its config screen via PolyLib automatically appears in Mod Menu. Declared as `suggests` dep so it only activates when ModMenu is present.
- **`NeoForgeConfigHelper`** (`neoforge`): registers a config screen with both `ConfigPanelRegistry` AND NeoForge's `IConfigScreenFactory` extension point in one call.
- **`NeoForgeClientEvents`**: wires `ConfigPanelRegistry.tickKeybinds()` to the client tick event.
- `fabric.mod.json`: adds `modmenu` entrypoint; changes `suggests` from placeholder to `modmenu`.
- `PolyConfig.configPanelKeybinds`: per-mod-id flag map controlling whether keybind shortcuts are enabled.

Depends on `feat/build-modernize` for the ModMenu `compileOnly` dependency.