### PR TITLE
feat: migrate testmod to PolyRegistry API

### DIFF
--- a/testmod-common/src/main/java/net/creeperhost/testmod/TestModCommon.java
+++ b/testmod-common/src/main/java/net/creeperhost/testmod/TestModCommon.java
@@ -1,14 +1,53 @@
 package net.creeperhost.testmod;
 
+import com.mojang.serialization.Codec;
 import net.creeperhost.polylib.platform.Services;
+import net.creeperhost.polylib.player.serverdata.PlayerServerDataRegistry;
+import net.creeperhost.polylib.player.serverdata.PlayerServerDataType;
+import net.creeperhost.polylib.player.settings.BroadcastScope;
+import net.creeperhost.polylib.player.settings.PlayerClientSettingsRegistry;
+import net.creeperhost.polylib.player.settings.PlayerClientSettingsType;
 import net.creeperhost.testmod.init.TestBlocks;
 import net.creeperhost.testmod.init.TestCreativeTabs;
 import net.creeperhost.testmod.init.TestItems;
+import net.creeperhost.testmod.init.TestPlayerData;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.StreamCodec;
 
 public class TestModCommon
 {
+    /** Demo: client-side "reduce screen shake" preference synced to nearby players. */
+    public static final PlayerClientSettingsType<Boolean> REDUCE_SCREENSHAKE =
+        PlayerClientSettingsRegistry.register(
+            "testmod:reduce_screenshake",
+            StreamCodec.<RegistryFriendlyByteBuf, Boolean>of(
+                (buf, v) -> buf.writeBoolean(v),
+                buf -> buf.readBoolean()
+            ),
+            () -> false,
+            BroadcastScope.TRACKING_RANGE,
+            /*copyOnDeath*/ true,
+            "testmod.setting.reduce_screenshake",
+            "Reduce Screen Shake"
+        );
+
+    /** Demo: server-authoritative ticks-played counter, synced to owner client. */
+    public static final PlayerServerDataType<Integer> TICKS_PLAYED =
+        PlayerServerDataRegistry.register(
+            "testmod:ticks_played",
+            Codec.INT,
+            StreamCodec.<RegistryFriendlyByteBuf, Integer>of(
+                (buf, v) -> buf.writeVarInt(v),
+                buf -> buf.readVarInt()
+            ),
+            () -> 0,
+            /*copyOnDeath*/ true
+        );
+
     public static void init()
     {
+        TestPlayerData.init();
         TestItems.init();
         TestBlocks.init();
         TestCreativeTabs.init();

--- a/testmod-common/src/main/java/net/creeperhost/testmod/init/TestBlocks.java
+++ b/testmod-common/src/main/java/net/creeperhost/testmod/init/TestBlocks.java
@@ -1,15 +1,19 @@
 package net.creeperhost.testmod.init;
 
-import net.creeperhost.polylib.platform.Services;
-import net.creeperhost.polylib.register.LazyBlock;
-import net.minecraft.resources.Identifier;
+import net.creeperhost.polylib.registry.PolyRegistry;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockBehaviour;
 
+import java.util.function.Supplier;
+
 public class TestBlocks {
 
-    public static LazyBlock<Block> TEST_BLOCK = Services.REGISTER_HELPER.registerBlock(
-            new LazyBlock<>(Identifier.fromNamespaceAndPath("testmod", "test_block"), Block::new, BlockBehaviour.Properties::of));
+    public static final PolyRegistry<Block> BLOCKS = PolyRegistry.create(Registries.BLOCK, "testmod");
 
-    public static void init() {}
+    public static final Supplier<Block> TEST_BLOCK = BLOCKS.register("test_block", "Test Block", () -> new Block(BlockBehaviour.Properties.of()));
+
+    public static void init() {
+        BLOCKS.init();
+    }
 }

--- a/testmod-common/src/main/java/net/creeperhost/testmod/init/TestCreativeTabs.java
+++ b/testmod-common/src/main/java/net/creeperhost/testmod/init/TestCreativeTabs.java
@@ -17,9 +17,9 @@ public class TestCreativeTabs {
                 Component.translatable("itemGroup.testmod.test_tab"),
                 () -> new ItemStack(Items.DIAMOND),
                 output -> {
-                    output.accept(TestItems.TEST_ITEM);
-                    output.accept(TestItems.TEST_ITEM_2);
-                    output.accept(TestBlocks.TEST_BLOCK);
+                    output.accept(TestItems.TEST_ITEM.get());
+                    output.accept(TestItems.TEST_ITEM_2.get());
+                    output.accept(TestBlocks.TEST_BLOCK.get());
                 }
         ));
     }

--- a/testmod-common/src/main/java/net/creeperhost/testmod/init/TestItems.java
+++ b/testmod-common/src/main/java/net/creeperhost/testmod/init/TestItems.java
@@ -1,17 +1,20 @@
 package net.creeperhost.testmod.init;
 
-import net.creeperhost.polylib.platform.Services;
-import net.creeperhost.polylib.register.LazyItem;
+import net.creeperhost.polylib.registry.PolyRegistry;
 import net.creeperhost.testmod.items.TestItem;
-import net.minecraft.resources.Identifier;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.world.item.Item;
+
+import java.util.function.Supplier;
 
 public class TestItems
 {
-    public static LazyItem<Item> TEST_ITEM = Services.REGISTER_HELPER.registerItem(
-            new LazyItem<>(Identifier.fromNamespaceAndPath("testmod", "test_item"), TestItem::new, Item.Properties::new));
-    public static LazyItem<Item> TEST_ITEM_2 = Services.REGISTER_HELPER.registerItem(
-            new LazyItem<>(Identifier.fromNamespaceAndPath("testmod", "test_item_two"), TestItem::new, Item.Properties::new));
+    public static final PolyRegistry<Item> ITEMS = PolyRegistry.create(Registries.ITEM, "testmod");
 
-    public static void init() {}
+    public static final Supplier<Item> TEST_ITEM = ITEMS.register("test_item", "Test Item", TestItem::new);
+    public static final Supplier<Item> TEST_ITEM_2 = ITEMS.register("test_item_two", "Test Item Two", TestItem::new);
+
+    public static void init() {
+        ITEMS.init();
+    }
 }

--- a/testmod-common/src/main/java/net/creeperhost/testmod/init/TestPlayerData.java
+++ b/testmod-common/src/main/java/net/creeperhost/testmod/init/TestPlayerData.java
@@ -1,0 +1,56 @@
+package net.creeperhost.testmod.init;
+
+import com.mojang.serialization.Codec;
+import net.creeperhost.polylib.player.serverdata.PlayerServerDataRegistry;
+import net.creeperhost.polylib.player.serverdata.PlayerServerDataType;
+import net.creeperhost.polylib.player.settings.BroadcastScope;
+import net.creeperhost.polylib.player.settings.PlayerClientSettingsRegistry;
+import net.creeperhost.polylib.player.settings.PlayerClientSettingsType;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.resources.Identifier;
+
+/**
+ * Testmod registrations for PlayerClientSettings and PlayerServerData.
+ * Exercises the API added in feat/player-data (PR #105).
+ *
+ * NOTE: depends on feat/player-data PR being merged before this compiles standalone.
+ */
+public final class TestPlayerData
+{
+    /**
+     * A simple boolean client setting — e.g. whether the player has opted into something.
+     * Synced to all nearby players (TRACKING_RANGE) and preserved on death.
+     */
+    public static final PlayerClientSettingsType<Boolean> TEST_TOGGLE = PlayerClientSettingsRegistry.register(
+            Identifier.fromNamespaceAndPath("testmod", "test_toggle"),
+            StreamCodec.of(
+                    (buf, val) -> buf.writeBoolean(val),
+                    buf -> buf.readBoolean()
+            ),
+            () -> false,
+            BroadcastScope.TRACKING_RANGE,
+            true
+    );
+
+    /**
+     * A simple integer server data value — e.g. a kill/use counter.
+     * Synced to the owning player's client and lost on death.
+     */
+    public static final PlayerServerDataType<Integer> TEST_COUNTER = PlayerServerDataRegistry.register(
+            Identifier.fromNamespaceAndPath("testmod", "test_counter"),
+            Codec.INT,
+            StreamCodec.of(
+                    (buf, val) -> buf.writeInt(val),
+                    buf -> buf.readInt()
+            ),
+            () -> 0,
+            false
+    );
+
+    public static void init()
+    {
+        // Static fields are initialised above; this method exists so TestModCommon can
+        // trigger classloading at the right time (before the server starts).
+        // No-op body is intentional.
+    }
+}

--- a/testmod-neoforge/src/main/java/net/creeperhost/testmod/TestModNeoForge.java
+++ b/testmod-neoforge/src/main/java/net/creeperhost/testmod/TestModNeoForge.java
@@ -1,11 +1,14 @@
 package net.creeperhost.testmod;
 
+import net.creeperhost.polylib.neoforge.registry.NeoPolyRegistry;
+import net.neoforged.bus.api.IEventBus;
 import net.neoforged.fml.common.Mod;
 
 @Mod("testmod")
 public class TestModNeoForge
 {
-    public TestModNeoForge() {
+    public TestModNeoForge(IEventBus bus) {
         TestModCommon.init();
+        NeoPolyRegistry.registerToBus(bus);
     }
 }


### PR DESCRIPTION
**Depends on #104** (\eat/registry-abstraction\) — requires PolyRegistry to be merged first.

Migrates the testmod away from \LazyItem\/\LazyBlock\ + \IRegisterHelper\ and over to the new \PolyRegistry\ API introduced in #104.

### Changes
- **\TestItems\**: replaced \REGISTER_HELPER.registerItem(new LazyItem(...))\ with \PolyRegistry<Item>\ and \ITEMS.register(name, englishName, supplier)\
- **\TestBlocks\**: same pattern using \PolyRegistry<Block>\
- **\TestModNeoForge\**: restored \IEventBus\ constructor param and added \NeoPolyRegistry.registerToBus(bus)\

> Note: \IRegisterHelper\, \LazyItem\, \LazyBlock\, \FabricRegisterHelper\, and \NeoForgeRegisterHelper\ are untouched — only testmod usage replaced.