### PR TITLE
fix: resolve testmod build errors after PR #108 merge

### DIFF
--- a/testmod-common/src/main/java/net/creeperhost/testmod/TestModCommon.java
+++ b/testmod-common/src/main/java/net/creeperhost/testmod/TestModCommon.java
@@ -11,16 +11,16 @@ import net.creeperhost.testmod.init.TestBlocks;
 import net.creeperhost.testmod.init.TestCreativeTabs;
 import net.creeperhost.testmod.init.TestItems;
 import net.creeperhost.testmod.init.TestPlayerData;
-import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.resources.Identifier;
 
 public class TestModCommon
 {
     /** Demo: client-side "reduce screen shake" preference synced to nearby players. */
     public static final PlayerClientSettingsType<Boolean> REDUCE_SCREENSHAKE =
         PlayerClientSettingsRegistry.register(
-            "testmod:reduce_screenshake",
+            Identifier.fromNamespaceAndPath("testmod", "reduce_screenshake"),
             StreamCodec.<RegistryFriendlyByteBuf, Boolean>of(
                 (buf, v) -> buf.writeBoolean(v),
                 buf -> buf.readBoolean()
@@ -35,7 +35,7 @@ public class TestModCommon
     /** Demo: server-authoritative ticks-played counter, synced to owner client. */
     public static final PlayerServerDataType<Integer> TICKS_PLAYED =
         PlayerServerDataRegistry.register(
-            "testmod:ticks_played",
+            Identifier.fromNamespaceAndPath("testmod", "ticks_played"),
             Codec.INT,
             StreamCodec.<RegistryFriendlyByteBuf, Integer>of(
                 (buf, v) -> buf.writeVarInt(v),

--- a/testmod-common/src/main/java/net/creeperhost/testmod/init/TestItems.java
+++ b/testmod-common/src/main/java/net/creeperhost/testmod/init/TestItems.java
@@ -11,8 +11,8 @@ public class TestItems
 {
     public static final PolyRegistry<Item> ITEMS = PolyRegistry.create(Registries.ITEM, "testmod");
 
-    public static final Supplier<Item> TEST_ITEM = ITEMS.register("test_item", "Test Item", TestItem::new);
-    public static final Supplier<Item> TEST_ITEM_2 = ITEMS.register("test_item_two", "Test Item Two", TestItem::new);
+    public static final Supplier<Item> TEST_ITEM = ITEMS.register("test_item", "Test Item", () -> new TestItem(new Item.Properties()));
+    public static final Supplier<Item> TEST_ITEM_2 = ITEMS.register("test_item_two", "Test Item Two", () -> new TestItem(new Item.Properties()));
 
     public static void init() {
         ITEMS.init();


### PR DESCRIPTION
## Summary

Fixes two build-breaking bugs in the testmod introduced after all PRs (#103–#108) were merged to `multi/26.1.2`.

## Changes

### `TestItems.java`
- `TestItem::new` is a constructor reference (`Function<Item.Properties, Item>`), **not** a `Supplier<Item>`. Changed to explicit lambdas:
  ```java
  () -> new TestItem(new Item.Properties())
  ```

### `TestModCommon.java`
- `PlayerClientSettingsRegistry.register()` and `PlayerServerDataRegistry.register()` require an `Identifier` as the first argument, not a `String`. Changed raw string IDs to `Identifier.fromNamespaceAndPath(...)`.
- Added missing `import net.minecraft.resources.Identifier;`.
- Removed spurious `import net.minecraft.network.FriendlyByteBuf;` (wrong type; `RegistryFriendlyByteBuf` is already imported).

## Verification

`./gradlew publishToMavenLocal` builds cleanly after these changes.