### PR TITLE
fix: use @code instead of @link for NeoForge LanguageProvider in Javadoc

### DIFF
--- a/common/src/main/java/net/creeperhost/polylib/data/lang/PolyLangContributions.java
+++ b/common/src/main/java/net/creeperhost/polylib/data/lang/PolyLangContributions.java
@@ -19,7 +19,7 @@ import java.util.function.BiConsumer;
  *
  * <p>Consumed by {@code PolyLibLangProvider} in PolyLib's NeoForge module during datagen.
  * Mod lang providers should extend {@code PolyLibLangProvider} instead of
- * {@link net.neoforged.neoforge.common.data.LanguageProvider} directly to receive
+ * {@code LanguageProvider} directly to receive
  * all contributions automatically.
  *
  * <p>Thread-safe. First registration wins — later contributions for an existing key are ignored,


### PR DESCRIPTION
## Summary

Fixes a Javadoc warning emitted during the Fabric `javadoc` task:

```
PolyLangContributions.java:22: warning: reference not found: net.neoforged.neoforge.common.data.LanguageProvider
```

## Root Cause

`{@link net.neoforged.neoforge.common.data.LanguageProvider}` is a cross-module reference. During the Fabric build, NeoForge classes are not on the compile classpath, so the Javadoc tool cannot resolve it.

## Fix

Changed to `{@code LanguageProvider}` — a plain code-formatted text reference that requires no classpath resolution. The documentation meaning is identical.