### PR TITLE
feat(registry): add registerItem/registerBlock helpers that inject registry key into Properties.setId()

### DIFF
--- a/common/src/main/java/net/creeperhost/polylib/registry/PolyRegistry.java
+++ b/common/src/main/java/net/creeperhost/polylib/registry/PolyRegistry.java
@@ -4,7 +4,11 @@ import net.creeperhost.polylib.data.lang.PolyLangContributions;
 import net.creeperhost.polylib.platform.Services;
 import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceKey;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockBehaviour;
 
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 public abstract class PolyRegistry<T> {
@@ -63,6 +67,87 @@ public abstract class PolyRegistry<T> {
     {
         PolyLangContributions.contribute(langKeyPrefix + "." + modId + "." + name, defaultEnglish);
         return register(name, supplier);
+    }
+
+    /**
+     * Registers a new object, passing its {@link ResourceKey} to the factory before construction.
+     *
+     * <p>Use this (or the {@link #registerItem}/{@link #registerBlock} helpers) whenever the
+     * object needs its registry key at construction time. On NeoForge this is required for
+     * {@link Item} and {@link Block} so that {@code Item.Properties#setId} /
+     * {@code BlockBehaviour.Properties#setId} can be called before the constructor runs.
+     *
+     * @param name    Registry name (path)
+     * @param factory Factory that receives the entry's {@code ResourceKey} and returns the object
+     * @return A supplier returning the registered object
+     */
+    public abstract <I extends T> Supplier<I> registerWithKey(String name, Function<ResourceKey<T>, ? extends I> factory);
+
+    /**
+     * Registers an {@link Item} subclass, automatically injecting the registry key into
+     * {@link Item.Properties} via {@code setId()} before the constructor runs.
+     *
+     * <p>Use this instead of {@link #register(String, Supplier)} for all item registrations so
+     * that NeoForge's item-id requirement is satisfied.
+     *
+     * @param name    Registry name (path), e.g. {@code "void_blade"}
+     * @param factory Constructor reference or lambda accepting pre-keyed {@link Item.Properties}
+     * @return A supplier returning the registered item
+     */
+    @SuppressWarnings("unchecked")
+    public final <I extends T> Supplier<I> registerItem(String name, Function<Item.Properties, ? extends I> factory)
+    {
+        return registerWithKey(name, key ->
+                factory.apply(new Item.Properties().setId((ResourceKey<Item>) (ResourceKey<?>) key)));
+    }
+
+    /**
+     * Registers an {@link Item} subclass with a default English translation, automatically
+     * injecting the registry key into {@link Item.Properties} via {@code setId()}.
+     *
+     * @param name           Registry name (path), e.g. {@code "void_blade"}
+     * @param defaultEnglish Default English display name, e.g. {@code "Void Blade"}
+     * @param factory        Constructor reference or lambda accepting pre-keyed {@link Item.Properties}
+     * @return A supplier returning the registered item
+     */
+    @SuppressWarnings("unchecked")
+    public final <I extends T> Supplier<I> registerItem(String name, String defaultEnglish, Function<Item.Properties, ? extends I> factory)
+    {
+        PolyLangContributions.contribute(langKeyPrefix + "." + modId + "." + name, defaultEnglish);
+        return registerWithKey(name, key ->
+                factory.apply(new Item.Properties().setId((ResourceKey<Item>) (ResourceKey<?>) key)));
+    }
+
+    /**
+     * Registers a {@link Block} subclass, automatically injecting the registry key into
+     * {@link BlockBehaviour.Properties} via {@code setId()} before the constructor runs.
+     *
+     * @param name    Registry name (path), e.g. {@code "copper_ore"}
+     * @param factory Constructor reference or lambda accepting pre-keyed {@link BlockBehaviour.Properties}
+     * @return A supplier returning the registered block
+     */
+    @SuppressWarnings("unchecked")
+    public final <I extends T> Supplier<I> registerBlock(String name, Function<BlockBehaviour.Properties, ? extends I> factory)
+    {
+        return registerWithKey(name, key ->
+                factory.apply(BlockBehaviour.Properties.of().setId((ResourceKey<Block>) (ResourceKey<?>) key)));
+    }
+
+    /**
+     * Registers a {@link Block} subclass with a default English translation, automatically
+     * injecting the registry key into {@link BlockBehaviour.Properties} via {@code setId()}.
+     *
+     * @param name           Registry name (path), e.g. {@code "copper_ore"}
+     * @param defaultEnglish Default English display name, e.g. {@code "Copper Ore"}
+     * @param factory        Constructor reference or lambda accepting pre-keyed {@link BlockBehaviour.Properties}
+     * @return A supplier returning the registered block
+     */
+    @SuppressWarnings("unchecked")
+    public final <I extends T> Supplier<I> registerBlock(String name, String defaultEnglish, Function<BlockBehaviour.Properties, ? extends I> factory)
+    {
+        PolyLangContributions.contribute(langKeyPrefix + "." + modId + "." + name, defaultEnglish);
+        return registerWithKey(name, key ->
+                factory.apply(BlockBehaviour.Properties.of().setId((ResourceKey<Block>) (ResourceKey<?>) key)));
     }
 
     /**

--- a/fabric/src/main/java/net/creeperhost/polylib/fabric/registry/FabricPolyRegistry.java
+++ b/fabric/src/main/java/net/creeperhost/polylib/fabric/registry/FabricPolyRegistry.java
@@ -9,6 +9,7 @@ import net.minecraft.resources.Identifier;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 public class FabricPolyRegistry<T> extends PolyRegistry<T> {
@@ -26,6 +27,15 @@ public class FabricPolyRegistry<T> extends PolyRegistry<T> {
         // Memoize so that calling get() on the returned supplier multiple times only initializes the object once
         Supplier<I> memoized = Suppliers.memoize(supplier::get);
         entries.put(name, memoized);
+        return memoized;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <I extends T> Supplier<I> registerWithKey(String name, Function<ResourceKey<T>, ? extends I> factory) {
+        ResourceKey<T> key = ResourceKey.create(registryKey, Identifier.fromNamespaceAndPath(modId, name));
+        Supplier<I> memoized = Suppliers.memoize(() -> factory.apply(key));
+        entries.put(name, (Supplier<? extends T>) memoized);
         return memoized;
     }
 

--- a/neoforge/src/main/java/net/creeperhost/polylib/neoforge/registry/NeoPolyRegistry.java
+++ b/neoforge/src/main/java/net/creeperhost/polylib/neoforge/registry/NeoPolyRegistry.java
@@ -8,6 +8,7 @@ import net.neoforged.neoforge.registries.DeferredRegister;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 public class NeoPolyRegistry<T> extends PolyRegistry<T> {
@@ -15,10 +16,12 @@ public class NeoPolyRegistry<T> extends PolyRegistry<T> {
     // Keeps track of all created registries so they can be bulk-attached to the ModEventBus
     private static final List<NeoPolyRegistry<?>> ALL_REGISTRIES = new ArrayList<>();
     
+    private final ResourceKey<? extends Registry<T>> registryKey;
     private final DeferredRegister<T> deferredRegister;
 
     public NeoPolyRegistry(ResourceKey<? extends Registry<T>> registryKey, String modId) {
         super(registryKey, modId);
+        this.registryKey = registryKey;
         this.deferredRegister = DeferredRegister.create(registryKey, modId);
         ALL_REGISTRIES.add(this);
     }
@@ -27,6 +30,11 @@ public class NeoPolyRegistry<T> extends PolyRegistry<T> {
     public <I extends T> Supplier<I> register(String name, Supplier<I> supplier) {
         // Delegate directly to NeoForge's DeferredRegister
         return deferredRegister.register(name, supplier);
+    }
+
+    @Override
+    public <I extends T> Supplier<I> registerWithKey(String name, Function<ResourceKey<T>, ? extends I> factory) {
+        return deferredRegister.register(name, key -> factory.apply(ResourceKey.create(registryKey, key)));
     }
 
     @Override

--- a/testmod-common/src/main/java/net/creeperhost/testmod/init/TestBlocks.java
+++ b/testmod-common/src/main/java/net/creeperhost/testmod/init/TestBlocks.java
@@ -3,10 +3,7 @@ package net.creeperhost.testmod.init;
 import net.creeperhost.polylib.registry.PolyRegistry;
 import net.creeperhost.testmod.TestModCommon;
 import net.minecraft.core.registries.Registries;
-import net.minecraft.resources.Identifier;
-import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.state.BlockBehaviour;
 
 import java.util.function.Supplier;
 
@@ -14,7 +11,7 @@ public class TestBlocks {
 
     public static final PolyRegistry<Block> BLOCKS = PolyRegistry.create(Registries.BLOCK, TestModCommon.MOD_ID);
 
-    public static final Supplier<Block> TEST_BLOCK = BLOCKS.register("test_block", "Test Block", () -> new Block(BlockBehaviour.Properties.of().setId(ResourceKey.create(Registries.BLOCK, Identifier.fromNamespaceAndPath(TestModCommon.MOD_ID, "test_block")))));
+    public static final Supplier<Block> TEST_BLOCK = BLOCKS.registerBlock("test_block", "Test Block", Block::new);
 
     public static void init() {
         BLOCKS.init();

--- a/testmod-common/src/main/java/net/creeperhost/testmod/init/TestItems.java
+++ b/testmod-common/src/main/java/net/creeperhost/testmod/init/TestItems.java
@@ -4,8 +4,6 @@ import net.creeperhost.polylib.registry.PolyRegistry;
 import net.creeperhost.testmod.TestModCommon;
 import net.creeperhost.testmod.items.TestItem;
 import net.minecraft.core.registries.Registries;
-import net.minecraft.resources.Identifier;
-import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.Item;
 
@@ -15,9 +13,9 @@ public class TestItems
 {
     public static final PolyRegistry<Item> ITEMS = PolyRegistry.create(Registries.ITEM, TestModCommon.MOD_ID);
 
-    public static final Supplier<Item> TEST_ITEM = ITEMS.register("test_item", "Test Item", () -> new TestItem(new Item.Properties().setId(ResourceKey.create(Registries.ITEM, Identifier.fromNamespaceAndPath(TestModCommon.MOD_ID, "test_item")))));
-    public static final Supplier<Item> TEST_ITEM_2 = ITEMS.register("test_item_two", "Test Item Two", () -> new TestItem(new Item.Properties().setId(ResourceKey.create(Registries.ITEM, Identifier.fromNamespaceAndPath(TestModCommon.MOD_ID, "test_item_two")))));
-    public static final Supplier<Item> TEST_BLOCK = ITEMS.register("test_block", "Test Block", () -> new BlockItem(TestBlocks.TEST_BLOCK.get(), new Item.Properties().setId(ResourceKey.create(Registries.ITEM, Identifier.fromNamespaceAndPath(TestModCommon.MOD_ID, "test_block")))));
+    public static final Supplier<Item> TEST_ITEM = ITEMS.registerItem("test_item", "Test Item", TestItem::new);
+    public static final Supplier<Item> TEST_ITEM_2 = ITEMS.registerItem("test_item_two", "Test Item Two", TestItem::new);
+    public static final Supplier<Item> TEST_BLOCK = ITEMS.registerItem("test_block", "Test Block", props -> new BlockItem(TestBlocks.TEST_BLOCK.get(), props));
 
     public static void init() {
         ITEMS.init();


### PR DESCRIPTION
## Problem

`PolyRegistry.register(String, Supplier<I>)` creates items and blocks without passing their registry key, so `Item.Properties.setId()` / `BlockBehaviour.Properties.setId()` are never called. On NeoForge 26.1.x this causes items and blocks to have no registered ID, leading to missing-name / crash-on-use errors.

The root cause: `DeferredRegister.Items.registerItem()` is the correct NeoForge API — it automatically calls `properties.setId(ResourceKey)` before the constructor. `DeferredRegister.register(String, Supplier)` does not.

## Solution

### `PolyRegistry` — new abstract method + convenience helpers

Added `registerWithKey(String, Function<ResourceKey<T>, I>)` as an abstract method that passes the entry's `ResourceKey` to the factory.

Built `registerItem` and `registerBlock` convenience helpers on top of it that pre-configure `Item.Properties` / `BlockBehaviour.Properties` with `setId()`:

```java
// Before (ID not set — broken on NeoForge):
ITEMS.register("test_item", "Test Item", () -> new TestItem(new Item.Properties()));

// After (ID injected automatically):
ITEMS.registerItem("test_item", "Test Item", TestItem::new);
BLOCKS.registerBlock("test_block", "Test Block", Block::new);
```

### `NeoPolyRegistry` — implement `registerWithKey`

Delegates to `DeferredRegister.register(String, Function<Identifier, I>)` and builds the `ResourceKey` from the `Identifier`.

### `FabricPolyRegistry` — implement `registerWithKey`

Builds the `ResourceKey` eagerly from the mod ID + name and memoizes the supplier.

### Testmod — updated to use the new API

- `TestItems`: `TestItem::new` (which is `Function<Item.Properties, TestItem>`) now works cleanly via `registerItem()`
- `TestBlocks`: `Block::new` via `registerBlock()`
- `TestModCommon`: also includes the `Identifier.fromNamespaceAndPath()` and import fixes needed for the player data registrations

## Verification

`./gradlew publishToMavenLocal` passes cleanly.