### PR TITLE
fix(player-data): lazy-load per-type NBT in get() to handle late class init

### DIFF
--- a/common/src/main/java/net/creeperhost/polylib/platform/services/IPlayerDataHelper.java
+++ b/common/src/main/java/net/creeperhost/polylib/platform/services/IPlayerDataHelper.java
@@ -44,4 +44,16 @@ public interface IPlayerDataHelper
      * Must call {@link PlayerServerDataStore#clearDirty()} after a successful save.
      */
     void saveServerData(UUID playerUUID, ServerPlayer player, PlayerServerDataStore store);
+
+    /**
+     * Load the persisted value for a single {@link PlayerServerDataType} into the store.
+     * Called lazily by {@link net.creeperhost.polylib.player.serverdata.PlayerServerDataManager#get}
+     * when a type is accessed that was not present in {@code registeredServerTypes} at login time
+     * (e.g. because the mod class was not yet initialized when {@code PlayerLoggedInEvent} fired).
+     *
+     * <p>If no persisted value exists the store is left unmodified; subsequent {@code store.get()}
+     * will return the type's default via {@code computeIfAbsent}.
+     */
+    <T> void loadServerDataForType(UUID playerUUID, ServerPlayer player,
+                                    PlayerServerDataStore store, PlayerServerDataType<T> type);
 }

--- a/common/src/main/java/net/creeperhost/polylib/player/serverdata/PlayerServerDataManager.java
+++ b/common/src/main/java/net/creeperhost/polylib/player/serverdata/PlayerServerDataManager.java
@@ -80,11 +80,20 @@ public final class PlayerServerDataManager
     /**
      * Returns the current value for a player. Server-side only.
      * Returns the type's default if the player has no active store.
+     *
+     * <p><b>Lazy-load:</b> if the store exists but has never seen this type (i.e. the type was
+     * registered after {@code PlayerLoggedInEvent} fired due to Java's lazy class initialisation),
+     * we attempt a single NBT read from the player's persistent data before returning the default.
+     * This makes registration order irrelevant in production and removes the need for mods to call
+     * a no-op {@code init()} method to force-load their registry class.
      */
     public static <T> T get(ServerPlayer player, PlayerServerDataType<T> type)
     {
         PlayerServerDataStore store = STORES.get(player.getUUID());
         if (store == null) return type.defaultFactory().get();
+        // Lazy load: type registered after login (late class init) — pull from NBT now.
+        if (!store.has(type))
+            Services.PLAYER_DATA.loadServerDataForType(player.getUUID(), player, store, type);
         return store.get(type);
     }
 

--- a/fabric/src/main/java/net/creeperhost/polylib/platform/FabricPlayerDataHelper.java
+++ b/fabric/src/main/java/net/creeperhost/polylib/platform/FabricPlayerDataHelper.java
@@ -178,5 +178,16 @@ public class FabricPlayerDataHelper implements IPlayerDataHelper
         if (attachment != null)
             player.setAttached(attachment, store.get(type));
     }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> void loadServerDataForType(UUID playerUUID, ServerPlayer player,
+                                           PlayerServerDataStore store, PlayerServerDataType<T> type)
+    {
+        AttachmentType<T> attachment = (AttachmentType<T>) serverDataAttachments.get(type.id());
+        if (attachment == null) return;  // type registered after Fabric AttachmentRegistry locked — can't lazy-load
+        T value = player.getAttached(attachment);
+        if (value != null) store.load(type, value);
+    }
 }
 

--- a/neoforge/src/main/java/net/creeperhost/polylib/platform/NeoForgePlayerDataHelper.java
+++ b/neoforge/src/main/java/net/creeperhost/polylib/platform/NeoForgePlayerDataHelper.java
@@ -161,5 +161,19 @@ public class NeoForgePlayerDataHelper implements IPlayerDataHelper
                     persistent.put(key, wrapper);
                 });
     }
+
+    @Override
+    public <T> void loadServerDataForType(UUID playerUUID, ServerPlayer player,
+                                           PlayerServerDataStore store, PlayerServerDataType<T> type)
+    {
+        String key = SDATA_PREFIX + type.id().toString();
+        Tag raw = player.getPersistentData().get(key);
+        if (raw instanceof CompoundTag wrapper)
+        {
+            Tag inner = wrapper.get("v");
+            if (inner != null)
+                loadServerTyped(type, inner, store);
+        }
+    }
 }
 


### PR DESCRIPTION
## Problem

`PlayerServerDataType` tokens are registered as `static final` fields on mod-defined classes:

```java
public final class ModPlayerData {
    public static final PlayerServerDataType<PlayerAbilities> PLAYER_ABILITIES =
        PlayerServerDataRegistry.register(...);
}
```

Java initialises classes **lazily** — if nothing touches `ModPlayerData` before `PlayerLoggedInEvent` fires, the `register()` call never happens. PolyLib's `onPlayerLogin` handler calls `loadServerData()`, which iterates `registeredServerTypes` — an **empty map** at that point — reads nothing, and the player starts with defaults. The persisted NBT sitting in `player.getPersistentData()` is silently skipped.

There is no error, no warning, and no indication of data loss. Saves still work (every `set()` writes immediately), which makes the bug deceptive: data *appears* to save but resets on every server restart.

**Reported symptom (DisCraftHonored):** all player power unlocks (blink, domino, windblast, etc.) reset to locked after every server restart.

## Fix

`PlayerServerDataManager.get()` now checks `store.has(type)` before returning. On a cache miss it calls a new `IPlayerDataHelper.loadServerDataForType()` to pull the single type's value from persistent storage, then returns the loaded (or default) value. On all subsequent calls the type is present in the store and no extra I/O occurs.

### New method: `IPlayerDataHelper.loadServerDataForType()`

**NeoForge** — reads `polylib_sdata.<id>` key from `player.getPersistentData()`, same key used by bulk `loadServerData()`.

**Fabric** — looks up the `AttachmentType` registered for the given id and calls `player.getAttached()`. If the type was registered after `AttachmentRegistry` locked (a Fabric-specific constraint), a no-op is the safe path (no crash, falls back to default).

## Result

Registration order is now irrelevant. Mods no longer need to call an explicit no-op `init()` method to force class initialisation before the first login event.

## Files changed

| File | Change |
|------|--------|
| `IPlayerDataHelper` | New `loadServerDataForType()` method |
| `PlayerServerDataManager` | Lazy-load on cache miss in `get()` |
| `NeoForgePlayerDataHelper` | Implement `loadServerDataForType()` |
| `FabricPlayerDataHelper` | Implement `loadServerDataForType()` |