### PR TITLE
fix(fabric): invert ClientPreAttackCallback return — left-click was blocked on Fabric

### DIFF
--- a/fabric/src/main/java/net/creeperhost/polylib/PolyLibClientFabric.java
+++ b/fabric/src/main/java/net/creeperhost/polylib/PolyLibClientFabric.java
@@ -250,7 +250,7 @@ public class PolyLibClientFabric
             CancelContext ctx = new CancelContext();
             PolyClientInteractionEvents.CLIENT_PRE_ATTACK.invoker()
                     .onPreAttack(client, player, clickCount, ctx);
-            return !ctx.isCancelled();
+            return ctx.isCancelled();
         });
 
         // ── T17-A: Frame events ───────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

All left-click attacks were silently blocked on Fabric (`fabric-api-0.146.1+26.1.2`).

## Root Cause

`ClientPreAttackCallback.onClientPlayerPreAttack` returns **`true` to cancel** the attack (its array-backed combiner short-circuits and returns `true` as soon as any listener returns `true`).

The registration in `PolyLibClientFabric` was returning `!ctx.isCancelled()`, which with no PolyLib listeners registered evaluates to `!false = true` — telling Fabric API to cancel every left click.

## Fix

```java
// Before (broken)
return !ctx.isCancelled();

// After (correct)
return ctx.isCancelled();
```

Now the default path (`false` = nothing cancelled) correctly allows the attack through.

## Verified by

Inspecting the combiner bytecode of `ClientPreAttackCallback` extracted from `fabric-events-interaction-v0-5.1.10+c82f04614c.jar` (nested inside `fabric-api-0.146.1+26.1.2.jar`):

```
ifeq 40      // if result == false, continue loop
iconst_1
ireturn      // if result == true → cancel (early exit)
...
iconst_0
ireturn      // fell through all listeners → allow
```