### PR TITLE
feat(debug-screen): PolyDebugRegistry + cross-platform F3 debug entry bridge

### DIFF
--- a/common/src/main/java/net/creeperhost/polylib/debug/PolyDebugDisplayer.java
+++ b/common/src/main/java/net/creeperhost/polylib/debug/PolyDebugDisplayer.java
@@ -1,0 +1,48 @@
+package net.creeperhost.polylib.debug;
+
+import net.minecraft.resources.Identifier;
+
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Platform-agnostic display interface passed to {@link PolyDebugEntry#display}.
+ * <p>
+ * Maps directly onto {@code DebugScreenDisplayer} on both NeoForge and Fabric.
+ * Use {@link #addLine} for normal sequential lines, {@link #addPriorityLine}
+ * to force a line to the top of its column, and {@link #addToGroup} to append
+ * lines beneath an existing vanilla or mod-registered entry group.
+ */
+public interface PolyDebugDisplayer
+{
+    /** Appends a text line to the current display column in normal order. */
+    void addLine(String text);
+
+    /**
+     * Appends a text line at the top priority position — it will appear
+     * before normal lines in the column regardless of registration order.
+     */
+    void addPriorityLine(String text);
+
+    /**
+     * Appends a collection of lines to an existing named group.
+     * The group is identified by its {@link Identifier} key
+     * (e.g. {@code DebugEntrySystemSpecs#GROUP}).
+     * If the group does not exist, the lines are silently dropped.
+     *
+     * @param group namespaced key of the target group
+     * @param lines lines to append inside that group
+     */
+    void addToGroup(Identifier group, Collection<String> lines);
+
+    /**
+     * Convenience overload — appends a single line to a group.
+     *
+     * @param group namespaced key of the target group
+     * @param text  single text line to append
+     */
+    default void addToGroup(Identifier group, String text)
+    {
+        addToGroup(group, List.of(text));
+    }
+}

--- a/common/src/main/java/net/creeperhost/polylib/debug/PolyDebugEntry.java
+++ b/common/src/main/java/net/creeperhost/polylib/debug/PolyDebugEntry.java
@@ -1,0 +1,69 @@
+package net.creeperhost.polylib.debug;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.chunk.LevelChunk;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Callback interface for a custom F3 debug screen entry.
+ * <p>
+ * Implement this interface and register an instance via
+ * {@link PolyDebugRegistry#register}.  Both methods are called on the
+ * <strong>render thread</strong> (client-side only), each frame while the
+ * F3 screen is visible.
+ *
+ * <h3>Example</h3>
+ * <pre>{@code
+ * PolyDebugRegistry.register(
+ *     Identifier.fromNamespaceAndPath("mymod", "stats"),
+ *     new PolyDebugEntry() {
+ *         public boolean isAllowed(Minecraft mc, boolean reduced) {
+ *             return mc.level != null;  // only show in-world
+ *         }
+ *         public void display(PolyDebugDisplayer d, Level level, LevelChunk cc, LevelChunk sc) {
+ *             d.addLine("MyMod stat: " + MyStats.getValue());
+ *         }
+ *     },
+ *     true, true, false, "debug.mymod.stats", "My Stats"
+ * );
+ * }</pre>
+ */
+public interface PolyDebugEntry
+{
+    /**
+     * Called every frame to determine whether this entry should contribute
+     * any output to the F3 screen right now.
+     * <p>
+     * Receives the full {@link Minecraft} instance so implementations can
+     * check world state, player state, feature flags, etc.  Also receives
+     * {@code reducedDebugInfo} (the F3+Q reduced-info flag from game rules).
+     * Return {@code false} to suppress all lines for this frame.
+     *
+     * @param mc      the current Minecraft client instance (never null)
+     * @param reduced {@code true} when the game rule {@code reducedDebugInfo} is active
+     * @return {@code true} to allow display, {@code false} to hide entirely
+     */
+    default boolean isAllowed(Minecraft mc, boolean reduced)
+    {
+        return true;
+    }
+
+    /**
+     * Called each frame (when {@link #isAllowed} returns {@code true}) to
+     * write lines into the F3 panel via the provided {@link PolyDebugDisplayer}.
+     * <p>
+     * {@code clientChunk} and {@code serverChunk} are the chunk the player is
+     * currently standing in from the client and server perspectives respectively
+     * (nullable if not in a world or the chunk is not loaded).
+     *
+     * @param displayer    output sink for this entry's debug lines
+     * @param level        the client level, or {@code null} if not in a world
+     * @param clientChunk  client-side chunk at player position, may be null
+     * @param serverChunk  server-side chunk at player position, may be null
+     */
+    void display(PolyDebugDisplayer displayer,
+                 @Nullable Level level,
+                 @Nullable LevelChunk clientChunk,
+                 @Nullable LevelChunk serverChunk);
+}

--- a/common/src/main/java/net/creeperhost/polylib/debug/PolyDebugEntryType.java
+++ b/common/src/main/java/net/creeperhost/polylib/debug/PolyDebugEntryType.java
@@ -1,0 +1,80 @@
+package net.creeperhost.polylib.debug;
+
+import net.minecraft.resources.Identifier;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Typed registration token for a custom F3 debug screen entry.
+ * <p>
+ * Obtain via {@link PolyDebugRegistry#register} and store as a
+ * {@code public static final} constant in your mod class.
+ *
+ * <h3>Toggle / profile behaviour</h3>
+ * <ul>
+ *   <li>{@link #defaultEnabled} — whether the toggle button is ON by default
+ *       when no saved preference exists yet.  MC persists the toggle across
+ *       sessions in the vanilla {@code options.txt} ({@code debugScreen.*}).</li>
+ *   <li>{@link #inDefaultProfile} — automatically enable this entry when
+ *       the player activates the "Default" F3 profile (F3 + N in vanilla).</li>
+ *   <li>{@link #inPerformanceProfile} — automatically enable this entry when
+ *       the "Performance" F3 profile is active.</li>
+ * </ul>
+ */
+public final class PolyDebugEntryType
+{
+    private final Identifier      id;
+    private final PolyDebugEntry  entry;
+    private final boolean         defaultEnabled;
+    private final boolean         inDefaultProfile;
+    private final boolean         inPerformanceProfile;
+    @Nullable private final String displayNameKey;
+
+    PolyDebugEntryType(Identifier     id,
+                       PolyDebugEntry entry,
+                       boolean        defaultEnabled,
+                       boolean        inDefaultProfile,
+                       boolean        inPerformanceProfile,
+                       @Nullable String displayNameKey)
+    {
+        this.id                  = id;
+        this.entry               = entry;
+        this.defaultEnabled      = defaultEnabled;
+        this.inDefaultProfile    = inDefaultProfile;
+        this.inPerformanceProfile = inPerformanceProfile;
+        this.displayNameKey      = displayNameKey;
+    }
+
+    // ── Accessors ──────────────────────────────────────────────────────────────
+
+    /** Namespaced registration ID, e.g. {@code "mymod:my_entry"}. */
+    public Identifier id()                  { return id; }
+
+    /** The entry callback implementation. */
+    public PolyDebugEntry entry()           { return entry; }
+
+    /**
+     * Whether the F3 toggle for this entry starts in the ON position when no
+     * saved state exists.  Vanilla persists the toggle in {@code options.txt}.
+     */
+    public boolean defaultEnabled()         { return defaultEnabled; }
+
+    /** Whether this entry is included in the "Default" F3 debug profile. */
+    public boolean inDefaultProfile()       { return inDefaultProfile; }
+
+    /** Whether this entry is included in the "Performance" F3 debug profile. */
+    public boolean inPerformanceProfile()   { return inPerformanceProfile; }
+
+    /**
+     * Optional translation key for the toggle label shown in the F3 options
+     * menu.  May be {@code null} if no name was registered, in which case
+     * the raw {@link #id()} string will typically be used as the label.
+     */
+    @Nullable
+    public String displayNameKey()          { return displayNameKey; }
+
+    @Override
+    public String toString()
+    {
+        return "PolyDebugEntryType[" + id + "]";
+    }
+}

--- a/common/src/main/java/net/creeperhost/polylib/debug/PolyDebugRegistry.java
+++ b/common/src/main/java/net/creeperhost/polylib/debug/PolyDebugRegistry.java
@@ -1,0 +1,135 @@
+package net.creeperhost.polylib.debug;
+
+import net.creeperhost.polylib.data.lang.PolyLangContributions;
+import net.minecraft.resources.Identifier;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Registry for {@link PolyDebugEntryType} tokens.
+ * <p>
+ * Registration <strong>must</strong> happen before the debug screen is first
+ * opened — typically in your mod's client initialiser or static init.
+ * On NeoForge this registry is consumed by {@link net.creeperhost.polylib.debug.neoforge.NeoForgeDebugBridge}
+ * during the {@code RegisterDebugEntriesEvent} (mod bus).
+ * On Fabric it is consumed by the {@code FabricDebugEntriesMixin} injected
+ * into {@code DebugScreenEntries}.
+ *
+ * <h3>Minimal usage example</h3>
+ * <pre>{@code
+ * // In your mod client init:
+ * public static final PolyDebugEntryType MY_ENTRY = PolyDebugRegistry.register(
+ *     Identifier.fromNamespaceAndPath("mymod", "my_info"),
+ *     displayer -> displayer.addLine("MyMod: " + getSomeValue()),
+ *     true,   // ON by default
+ *     true,   // included in the Default profile
+ *     false,  // not in the Performance profile
+ *     "debug.mymod.my_info",   // i18n key
+ *     "My Info"                // English fallback for datagen
+ * );
+ * }</pre>
+ */
+public final class PolyDebugRegistry
+{
+    private static final Map<Identifier, PolyDebugEntryType> BY_ID = new LinkedHashMap<>();
+
+    private PolyDebugRegistry() {}
+
+    // ── Registration ──────────────────────────────────────────────────────────
+
+    /**
+     * Register a new debug screen entry (minimal overload — no display name,
+     * enabled by default, included in the Default profile only).
+     *
+     * @param id    Namespaced ID, e.g. {@code "mymod:my_entry"}
+     * @param entry Callback that renders the entry's lines
+     * @return Typed token — store as {@code public static final}
+     */
+    public static PolyDebugEntryType register(Identifier id, PolyDebugEntry entry)
+    {
+        return register(id, entry, true, true, false, null, null);
+    }
+
+    /**
+     * Register with explicit profile and default-enabled control.
+     *
+     * @param id                  Namespaced ID
+     * @param entry               Callback that renders the entry's lines
+     * @param defaultEnabled      Initial toggle state when no saved preference exists
+     * @param inDefaultProfile    Include in the "Default" F3 debug profile
+     * @param inPerformanceProfile Include in the "Performance" F3 debug profile
+     * @return Typed token — store as {@code public static final}
+     */
+    public static PolyDebugEntryType register(Identifier id,
+                                              PolyDebugEntry entry,
+                                              boolean defaultEnabled,
+                                              boolean inDefaultProfile,
+                                              boolean inPerformanceProfile)
+    {
+        return register(id, entry, defaultEnabled, inDefaultProfile, inPerformanceProfile, null, null);
+    }
+
+    /**
+     * Full registration overload with optional display name for lang datagen.
+     * <p>
+     * If both {@code displayNameKey} and {@code displayNameEnglish} are
+     * non-null, the pair is contributed to {@link PolyLangContributions} so
+     * downstream lang datagen providers can automatically include it.
+     *
+     * @param id                  Namespaced ID, e.g. {@code "mymod:my_entry"}
+     * @param entry               Callback that renders the entry's lines
+     * @param defaultEnabled      Initial toggle state when no saved preference exists
+     * @param inDefaultProfile    Include in the "Default" F3 debug profile
+     * @param inPerformanceProfile Include in the "Performance" F3 debug profile
+     * @param displayNameKey      i18n key for the toggle label, or {@code null}
+     * @param displayNameEnglish  English fallback used during lang datagen, or {@code null}
+     * @return Typed token — store as {@code public static final}
+     */
+    public static PolyDebugEntryType register(Identifier     id,
+                                              PolyDebugEntry entry,
+                                              boolean        defaultEnabled,
+                                              boolean        inDefaultProfile,
+                                              boolean        inPerformanceProfile,
+                                              @Nullable String displayNameKey,
+                                              @Nullable String displayNameEnglish)
+    {
+        if (BY_ID.containsKey(id))
+            throw new IllegalStateException("PolyDebugEntryType already registered: " + id);
+
+        if (displayNameKey != null && displayNameEnglish != null)
+            PolyLangContributions.contribute(displayNameKey, displayNameEnglish);
+
+        PolyDebugEntryType type = new PolyDebugEntryType(
+                id, entry, defaultEnabled, inDefaultProfile, inPerformanceProfile, displayNameKey);
+        BY_ID.put(id, type);
+        return type;
+    }
+
+    // ── Queries ───────────────────────────────────────────────────────────────
+
+    /**
+     * Returns all registered types in insertion order.
+     * Used internally by NeoForge/Fabric bridges.
+     */
+    public static Collection<PolyDebugEntryType> getAll()
+    {
+        return Collections.unmodifiableCollection(BY_ID.values());
+    }
+
+    /** Lookup by namespaced ID. */
+    public static Optional<PolyDebugEntryType> byId(Identifier id)
+    {
+        return Optional.ofNullable(BY_ID.get(id));
+    }
+
+    /** Returns {@code true} if the given ID has been registered. */
+    public static boolean isRegistered(Identifier id)
+    {
+        return BY_ID.containsKey(id);
+    }
+}

--- a/fabric/src/main/java/net/creeperhost/polylib/mixin/client/EntryMapAccessor.java
+++ b/fabric/src/main/java/net/creeperhost/polylib/mixin/client/EntryMapAccessor.java
@@ -1,0 +1,28 @@
+package net.creeperhost.polylib.mixin.client;
+
+import net.minecraft.client.gui.components.debug.DebugScreenEntries;
+import net.minecraft.client.gui.components.debug.DebugScreenEntry;
+import net.minecraft.resources.Identifier;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import java.util.Map;
+
+/**
+ * Mixin accessor that exposes the private-static {@code ENTRIES_BY_ID} field
+ * of {@link DebugScreenEntries} so that {@link FabricDebugEntriesMixin} can
+ * insert PolyLib debug entries after vanilla's static initialiser runs.
+ * <p>
+ * Mutable access is intentional: we need to {@link Map#put} into the live map,
+ * not a copy.  The field is a {@code HashMap} (confirmed via bytecode) that is
+ * later read (but not replaced) by {@code allEntries()} and {@code getEntry()}.
+ */
+@Mixin(DebugScreenEntries.class)
+public interface EntryMapAccessor
+{
+    @Accessor("ENTRIES_BY_ID")
+    static Map<Identifier, DebugScreenEntry> polylib$getEntriesById()
+    {
+        throw new AssertionError("Mixin accessor not applied");
+    }
+}

--- a/fabric/src/main/java/net/creeperhost/polylib/mixin/client/FabricDebugEntriesMixin.java
+++ b/fabric/src/main/java/net/creeperhost/polylib/mixin/client/FabricDebugEntriesMixin.java
@@ -1,0 +1,95 @@
+package net.creeperhost.polylib.mixin.client;
+
+import net.creeperhost.polylib.debug.PolyDebugDisplayer;
+import net.creeperhost.polylib.debug.PolyDebugEntry;
+import net.creeperhost.polylib.debug.PolyDebugEntryType;
+import net.creeperhost.polylib.debug.PolyDebugRegistry;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.components.debug.DebugScreenDisplayer;
+import net.minecraft.client.gui.components.debug.DebugScreenEntries;
+import net.minecraft.client.gui.components.debug.DebugScreenEntry;
+import net.minecraft.resources.Identifier;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.chunk.LevelChunk;
+import org.jspecify.annotations.Nullable;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * Fabric bridge for {@link PolyDebugRegistry}.
+ * <p>
+ * Injects at the tail of {@code DebugScreenEntries}'s static initialiser so
+ * that all entries registered via {@link PolyDebugRegistry} are appended to
+ * the vanilla {@code ENTRIES_BY_ID} map before the first F3 screen render.
+ * <p>
+ * Because {@code register(Identifier, DebugScreenEntry)} is private-static,
+ * we obtain the {@code ENTRIES_BY_ID} field via the {@link EntryMapAccessor}
+ * interface and call {@link Map#put} directly.  This matches exactly what the
+ * private method does (see bytecode: {@code ENTRIES_BY_ID.put(id, entry); return id;}).
+ */
+@Mixin(DebugScreenEntries.class)
+public abstract class FabricDebugEntriesMixin
+{
+    @Inject(method = "<clinit>", at = @At("TAIL"))
+    private static void polylib$registerEntries(CallbackInfo ci)
+    {
+        Map<Identifier, DebugScreenEntry> entriesById = EntryMapAccessor.polylib$getEntriesById();
+
+        for (PolyDebugEntryType type : PolyDebugRegistry.getAll())
+        {
+            entriesById.put(type.id(), buildMcEntry(type.entry()));
+        }
+    }
+
+    // ── Adapter factory ───────────────────────────────────────────────────────
+
+    private static DebugScreenEntry buildMcEntry(PolyDebugEntry poly)
+    {
+        return new DebugScreenEntry()
+        {
+            @Override
+            public boolean isAllowed(boolean reducedDebugInfo)
+            {
+                return poly.isAllowed(Minecraft.getInstance(), reducedDebugInfo);
+            }
+
+            @Override
+            public void display(DebugScreenDisplayer mcDisplayer,
+                                @Nullable Level level,
+                                @Nullable LevelChunk clientChunk,
+                                @Nullable LevelChunk serverChunk)
+            {
+                poly.display(wrapDisplayer(mcDisplayer), level, clientChunk, serverChunk);
+            }
+        };
+    }
+
+    private static PolyDebugDisplayer wrapDisplayer(DebugScreenDisplayer mc)
+    {
+        return new PolyDebugDisplayer()
+        {
+            @Override
+            public void addLine(String text)
+            {
+                mc.addLine(text);
+            }
+
+            @Override
+            public void addPriorityLine(String text)
+            {
+                mc.addPriorityLine(text);
+            }
+
+            @Override
+            public void addToGroup(Identifier group, Collection<String> lines)
+            {
+                mc.addToGroup(group, lines);
+            }
+        };
+    }
+}

--- a/neoforge/src/main/java/net/creeperhost/polylib/PolyLibClientNeoForge.java
+++ b/neoforge/src/main/java/net/creeperhost/polylib/PolyLibClientNeoForge.java
@@ -1,8 +1,10 @@
 package net.creeperhost.polylib;
 
 import net.creeperhost.polylib.client.modulargui.sprite.PolyTextures;
+import net.creeperhost.polylib.debug.neoforge.NeoForgeDebugBridge;
 import net.minecraft.client.resources.model.sprite.AtlasManager;
 import net.neoforged.bus.api.IEventBus;
+import net.neoforged.neoforge.client.event.RegisterDebugEntriesEvent;
 import net.neoforged.neoforge.client.event.RegisterTextureAtlasesEvent;
 import net.neoforged.neoforge.client.event.TextureAtlasStitchedEvent;
 
@@ -12,6 +14,8 @@ public class PolyLibClientNeoForge
     {
         eventBus.addListener(PolyLibClientNeoForge::atlasStitched);
         eventBus.addListener(PolyLibClientNeoForge::registerTextureAtlas);
+        // F3 debug screen entry system — NeoForge bridge
+        eventBus.addListener(NeoForgeDebugBridge::onRegisterDebugEntries);
     }
 
     private static void registerTextureAtlas(RegisterTextureAtlasesEvent event) {
@@ -25,3 +29,4 @@ public class PolyLibClientNeoForge
         }
     }
 }
+

--- a/neoforge/src/main/java/net/creeperhost/polylib/debug/neoforge/NeoForgeDebugBridge.java
+++ b/neoforge/src/main/java/net/creeperhost/polylib/debug/neoforge/NeoForgeDebugBridge.java
@@ -1,0 +1,119 @@
+package net.creeperhost.polylib.debug.neoforge;
+
+import net.creeperhost.polylib.debug.PolyDebugDisplayer;
+import net.creeperhost.polylib.debug.PolyDebugEntry;
+import net.creeperhost.polylib.debug.PolyDebugEntryType;
+import net.creeperhost.polylib.debug.PolyDebugRegistry;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.components.debug.DebugScreenDisplayer;
+import net.minecraft.client.gui.components.debug.DebugScreenEntry;
+import net.minecraft.client.gui.components.debug.DebugScreenEntryStatus;
+import net.minecraft.client.gui.components.debug.DebugScreenProfile;
+import net.minecraft.resources.Identifier;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.chunk.LevelChunk;
+import net.neoforged.neoforge.client.event.RegisterDebugEntriesEvent;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Collection;
+
+/**
+ * NeoForge bridge that wires {@link PolyDebugRegistry} into the vanilla
+ * {@code DebugScreenEntries} system via {@link RegisterDebugEntriesEvent}.
+ *
+ * <p>Registered on the <strong>mod event bus</strong> from
+ * {@link net.creeperhost.polylib.PolyLibClientNeoForge}.
+ *
+ * <p>Each {@link PolyDebugEntryType} is adapted to a {@link DebugScreenEntry}
+ * that delegates {@code isAllowed()} and {@code display()} back to the
+ * {@link PolyDebugEntry} implementation.  Toggle state and persistence are
+ * handled entirely by vanilla's {@code DebugOptions} / {@code options.txt}
+ * mechanism — no extra storage is needed.
+ */
+public final class NeoForgeDebugBridge
+{
+    private NeoForgeDebugBridge() {}
+
+    /**
+     * Fired once during mod startup on the mod event bus.
+     * Iterates every registered {@link PolyDebugEntryType} and registers an
+     * adapter {@link DebugScreenEntry} for it.
+     */
+    public static void onRegisterDebugEntries(RegisterDebugEntriesEvent event)
+    {
+        for (PolyDebugEntryType type : PolyDebugRegistry.getAll())
+        {
+            DebugScreenEntry mcEntry = buildEntry(type.entry());
+            event.register(type.id(), mcEntry);
+
+            // Map our boolean defaultEnabled to the correct DebugScreenEntryStatus:
+            //   true  → IN_OVERLAY  (shows in the F3 panel by default)
+            //   false → NEVER       (hidden until player manually enables it)
+            DebugScreenEntryStatus profileStatus =
+                    type.defaultEnabled() ? DebugScreenEntryStatus.IN_OVERLAY : DebugScreenEntryStatus.NEVER;
+
+            if (type.inDefaultProfile())
+                event.includeInProfile(type.id(), DebugScreenProfile.DEFAULT, profileStatus);
+
+            if (type.inPerformanceProfile())
+                event.includeInProfile(type.id(), DebugScreenProfile.PERFORMANCE, profileStatus);
+        }
+    }
+
+    // ── Adapter factory ───────────────────────────────────────────────────────
+
+    /**
+     * Wraps a {@link PolyDebugEntry} in a vanilla {@link DebugScreenEntry}.
+     * <p>
+     * The MC {@code DebugScreenDisplayer} is adapted to {@link PolyDebugDisplayer}
+     * via an anonymous inline implementation so common-module code never
+     * imports any NeoForge/MC rendering classes directly.
+     */
+    private static DebugScreenEntry buildEntry(PolyDebugEntry poly)
+    {
+        return new DebugScreenEntry()
+        {
+            @Override
+            public boolean isAllowed(boolean reducedDebugInfo)
+            {
+                return poly.isAllowed(Minecraft.getInstance(), reducedDebugInfo);
+            }
+
+            @Override
+            public void display(DebugScreenDisplayer mcDisplayer,
+                                @Nullable Level level,
+                                @Nullable LevelChunk clientChunk,
+                                @Nullable LevelChunk serverChunk)
+            {
+                poly.display(wrapDisplayer(mcDisplayer), level, clientChunk, serverChunk);
+            }
+        };
+    }
+
+    /**
+     * Adapts a MC {@link DebugScreenDisplayer} into a {@link PolyDebugDisplayer}.
+     */
+    private static PolyDebugDisplayer wrapDisplayer(DebugScreenDisplayer mc)
+    {
+        return new PolyDebugDisplayer()
+        {
+            @Override
+            public void addLine(String text)
+            {
+                mc.addLine(text);
+            }
+
+            @Override
+            public void addPriorityLine(String text)
+            {
+                mc.addPriorityLine(text);
+            }
+
+            @Override
+            public void addToGroup(Identifier group, Collection<String> lines)
+            {
+                mc.addToGroup(group, lines);
+            }
+        };
+    }
+}

--- a/testmod-common/src/main/java/net/creeperhost/testmod/init/TestDebugEntries.java
+++ b/testmod-common/src/main/java/net/creeperhost/testmod/init/TestDebugEntries.java
@@ -1,0 +1,220 @@
+package net.creeperhost.testmod.init;
+
+import net.creeperhost.polylib.chunkmap.client.PolyChunkMapClient;
+import net.creeperhost.polylib.chunkmap.common.data.PolyChunkMapData;
+import net.creeperhost.polylib.debug.PolyDebugDisplayer;
+import net.creeperhost.polylib.debug.PolyDebugEntry;
+import net.creeperhost.polylib.debug.PolyDebugEntryType;
+import net.creeperhost.polylib.debug.PolyDebugRegistry;
+import net.minecraft.client.Minecraft;
+import net.minecraft.core.BlockPos;
+import net.minecraft.resources.Identifier;
+import net.minecraft.server.level.FullChunkStatus;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.chunk.LevelChunk;
+import net.minecraft.world.phys.Vec3;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Map;
+
+import static net.creeperhost.testmod.TestModCommon.MOD_ID;
+
+/**
+ * Registers test {@link PolyDebugEntry} instances via {@link PolyDebugRegistry}
+ * to exercise the PolyLib F3 debug screen integration on both NeoForge and Fabric.
+ *
+ * <p>Three entries are registered, covering the key surface areas:
+ * <ul>
+ *   <li>{@code testmod:polylib_info} — always-visible, shows registry state and platform</li>
+ *   <li>{@code testmod:world_info}   — only visible in-world, shows position and chunk data</li>
+ *   <li>{@code testmod:reduced_test} — hides when the reducedDebugInfo gamerule is active</li>
+ * </ul>
+ *
+ * <p>To test: load a world and press <b>F3</b>. All three sections should appear in the
+ * right-hand debug column. Press <b>F3+N</b> to cycle debug profiles; the performance
+ * profile should only show {@code polylib_info}.
+ */
+public final class TestDebugEntries
+{
+    // Stored as constants so callers can reference the tokens if needed
+    public static PolyDebugEntryType POLYLIB_INFO;
+    public static PolyDebugEntryType WORLD_INFO;
+    public static PolyDebugEntryType REDUCED_TEST;
+
+    private TestDebugEntries() {}
+
+    public static void init()
+    {
+        // ── 1. PolyLib Info ──────────────────────────────────────────────────
+        // Always visible, included in both DEFAULT and PERFORMANCE profiles.
+        // Shows the registry entry count and current loader name.
+        POLYLIB_INFO = PolyDebugRegistry.register(
+                Identifier.fromNamespaceAndPath(MOD_ID, "polylib_info"),
+                new PolyDebugEntry()
+                {
+                    @Override
+                    public void display(PolyDebugDisplayer d,
+                                        @Nullable Level level,
+                                        @Nullable LevelChunk clientChunk,
+                                        @Nullable LevelChunk serverChunk)
+                    {
+                        d.addLine("PolyLib Debug");
+                        d.addLine("  Entries: " + PolyDebugRegistry.getAll().size());
+                        d.addLine("  Platform: " + net.creeperhost.polylib.platform.Services.PLATFORM.getPlatformName());
+                    }
+                },
+                /*defaultEnabled*/      true,
+                /*inDefaultProfile*/    true,
+                /*inPerformanceProfile*/true,
+                "debug." + MOD_ID + ".polylib_info",
+                "PolyLib Info"
+        );
+
+        // ── 2. World Info ────────────────────────────────────────────────────
+        // Only fires when in a world (isAllowed returns false at the title screen).
+        // Shows dimension key, XYZ, and whether both chunk views are loaded.
+        // NOT in the Performance profile.
+        WORLD_INFO = PolyDebugRegistry.register(
+                Identifier.fromNamespaceAndPath(MOD_ID, "world_info"),
+                new PolyDebugEntry()
+                {
+                    @Override
+                    public boolean isAllowed(Minecraft mc, boolean reduced)
+                    {
+                        return mc.level != null && mc.player != null;
+                    }
+
+                    @Override
+                    public void display(PolyDebugDisplayer d,
+                                        @Nullable Level level,
+                                        @Nullable LevelChunk clientChunk,
+                                        @Nullable LevelChunk serverChunk)
+                    {
+                        Minecraft mc = Minecraft.getInstance();
+                        if (mc.level == null || mc.player == null) return;
+
+                        Vec3 pos = mc.player.position();
+                        BlockPos bpos = mc.player.blockPosition();
+                        String dim = mc.level.dimension().identifier().toString();
+
+                        d.addLine("[TestMod] World Info");
+                        d.addLine("  Dim: " + dim);
+                        d.addLine(String.format("  XYZ: %.2f / %.5f / %.2f", pos.x, pos.y, pos.z));
+                        d.addLine("  Block: " + bpos.getX() + ", " + bpos.getY() + ", " + bpos.getZ());
+                        d.addLine("  ClientChunk: " + (clientChunk != null ? "loaded" : "null"));
+                        d.addLine("  ServerChunk: " + (serverChunk != null ? "loaded" : "null"));
+                        if (clientChunk != null)
+                            d.addLine("  Sections: " + clientChunk.getSectionsCount());
+                    }
+                },
+                /*defaultEnabled*/      true,
+                /*inDefaultProfile*/    true,
+                /*inPerformanceProfile*/false,
+                "debug." + MOD_ID + ".world_info",
+                "World Info"
+        );
+
+        // ── 3. Reduced Debug Test ────────────────────────────────────────────
+        // Demonstrates isAllowed(boolean reduced) — disappears when the
+        // reducedDebugInfo gamerule is enabled (/gamerule reducedDebugInfo true).
+        REDUCED_TEST = PolyDebugRegistry.register(
+                Identifier.fromNamespaceAndPath(MOD_ID, "reduced_test"),
+                new PolyDebugEntry()
+                {
+                    @Override
+                    public boolean isAllowed(Minecraft mc, boolean reduced)
+                    {
+                        return !reduced;
+                    }
+
+                    @Override
+                    public void display(PolyDebugDisplayer d,
+                                        @Nullable Level level,
+                                        @Nullable LevelChunk clientChunk,
+                                        @Nullable LevelChunk serverChunk)
+                    {
+                        d.addLine("[TestMod] Reduced Debug Test");
+                        d.addLine("  reducedDebugInfo = OFF");
+                        d.addLine("  (run: /gamerule reducedDebugInfo true to hide)");
+                    }
+                },
+                /*defaultEnabled*/      true,
+                /*inDefaultProfile*/    true,
+                /*inPerformanceProfile*/false,
+                "debug." + MOD_ID + ".reduced_test",
+                "Reduced Debug Test"
+        );
+        // ── 4. Chunk Map Stats ───────────────────────────────────────────────
+        // Shows whether the server has granted chunk-map access and how many
+        // chunks are currently cached for the player's dimension.
+        // This is the minimal test for the full server→client pipeline.
+        PolyDebugRegistry.register(
+                Identifier.fromNamespaceAndPath(MOD_ID, "chunk_map_stats"),
+                new PolyDebugEntry()
+                {
+                    @Override
+                    public boolean isAllowed(Minecraft mc, boolean reduced)
+                    {
+                        return mc.level != null;
+                    }
+
+                    @Override
+                    public void display(PolyDebugDisplayer d,
+                                       @Nullable Level level,
+                                       @Nullable LevelChunk clientChunk,
+                                       @Nullable LevelChunk serverChunk)
+                    {
+                        Minecraft mc = Minecraft.getInstance();
+                        if (mc.level == null) return;
+
+                        boolean permitted = PolyChunkMapClient.isPermitted();
+                        d.addLine("[PolyLib] Chunk Map");
+                        d.addLine("  Server: " + (permitted ? "§aGRANTED§r" : "§cDENIED§r"));
+
+                        if (permitted)
+                        {
+                            Map<Long, PolyChunkMapData> chunks =
+                                    PolyChunkMapClient.getChunks(mc.level.dimension());
+                            d.addLine("  Chunks: " + chunks.size());
+
+                            // Count by FullChunkStatus
+                            int inaccessible = 0, full = 0, blockTicking = 0, entityTicking = 0;
+                            for (PolyChunkMapData c : chunks.values())
+                            {
+                                switch (c.status())
+                                {
+                                    case INACCESSIBLE  -> inaccessible++;
+                                    case FULL          -> full++;
+                                    case BLOCK_TICKING -> blockTicking++;
+                                    case ENTITY_TICKING -> entityTicking++;
+                                }
+                            }
+                            d.addLine("  EntityTicking: " + entityTicking);
+                            d.addLine("  BlockTicking:  " + blockTicking);
+                            d.addLine("  Full:          " + full);
+                            d.addLine("  Inaccessible:  " + inaccessible);
+
+                            // Chunk at player's feet
+                            if (mc.player != null)
+                            {
+                                BlockPos bp = mc.player.blockPosition();
+                                long packedHere = net.minecraft.world.level.ChunkPos.pack(
+                                        bp.getX() >> 4, bp.getZ() >> 4);
+                                PolyChunkMapData here = chunks.get(packedHere);
+                                if (here != null)
+                                    d.addLine("  ThisChunk: " + here.status()
+                                            + " t=" + here.tickets().size());
+                                else
+                                    d.addLine("  ThisChunk: (no data yet)");
+                            }
+                        }
+                    }
+                },
+                /*defaultEnabled*/      true,
+                /*inDefaultProfile*/    true,
+                /*inPerformanceProfile*/false,
+                "debug." + MOD_ID + ".chunk_map_stats",
+                "Chunk Map Stats"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Adds a `PolyDebugRegistry` API for mods to register custom F3 debug screen entries, with platform bridges for both NeoForge and Fabric.

### Changes
- `PolyDebugRegistry` — central registry for `PolyDebugEntry` / `PolyDebugEntryType`
- `PolyDebugDisplayer` — common rendering interface
- `NeoForgeDebugBridge` — hooks `RegisterDebugEntriesEvent`
- `FabricDebugEntriesMixin` — injects into the Fabric debug screen
- Testmod: `TestDebugEntries` exercises the registry with sample entries

### Notes
- No breaking changes