### PR TITLE
feat(containers): add ContainerSyncProtocol network layer for ModularGuiContainerMenu

### DIFF
--- a/common/src/main/java/net/creeperhost/polylib/containers/ModularGuiContainerMenu.java
+++ b/common/src/main/java/net/creeperhost/polylib/containers/ModularGuiContainerMenu.java
@@ -26,6 +26,8 @@ import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
+import net.creeperhost.polylib.containers.network.PolyContainerSyncProtocol;
+
 /**
  * The base abstract ContainerMenu for all modular gui containers.
  * <p>
@@ -33,6 +35,8 @@ import java.util.function.Consumer;
  */
 public abstract class ModularGuiContainerMenu extends AbstractContainerMenu {
     private static final Logger LOGGER = LogManager.getLogger();
+
+    public final PolyContainerSyncProtocol syncProtocol = new PolyContainerSyncProtocol(this);
 
     public final Inventory inventory;
     public final List<SlotGroup> slotGroups = new ArrayList<>();
@@ -144,7 +148,9 @@ public abstract class ModularGuiContainerMenu extends AbstractContainerMenu {
      * Requires a client to server packet handler to be installed via {@link #setClientToServerPacketHandler(Consumer)}
      */
     public void handlePacketFromClient(Player player, int packetId, RegistryFriendlyByteBuf packet) {
-
+        if (packetId == 254) {
+            syncProtocol.handleClientPacket(player, packet);
+        }
     }
 
     public static void handlePacketFromServer(Player player, RegistryFriendlyByteBuf packet) {
@@ -162,6 +168,10 @@ public abstract class ModularGuiContainerMenu extends AbstractContainerMenu {
      * Don't forget to call super if you plan on using the {@link DataSync} system.
      */
     public void handlePacketFromServer(Player player, int packetId, RegistryFriendlyByteBuf packet) {
+        if (packetId == 254) {
+            syncProtocol.handleServerPacket(player, packet);
+            return;
+        }
         if (packetId == 255) {
             int index = packet.readByte() & 0xFF;
             if (dataSyncs.size() > index) {

--- a/common/src/main/java/net/creeperhost/polylib/containers/network/ContainerSyncProtocol.java
+++ b/common/src/main/java/net/creeperhost/polylib/containers/network/ContainerSyncProtocol.java
@@ -1,0 +1,38 @@
+package net.creeperhost.polylib.containers.network;
+
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.resources.Identifier;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.player.Player;
+
+import java.util.function.BiConsumer;
+
+/**
+ * Protocol adapter for synchronizing data between server and client containers.
+ * Replaces the need for raw byte buffer manipulation and manual packet ID assignments.
+ */
+public interface ContainerSyncProtocol {
+
+    /**
+     * Sends a typed payload to the client-side container.
+     */
+    <T> void sendToClient(ServerPlayer player, int containerId, SyncPayloadType<T> type, T payload);
+
+    /**
+     * Sends a typed payload to the server-side container.
+     */
+    <T> void sendToServer(int containerId, SyncPayloadType<T> type, T payload);
+
+    /**
+     * Registers a handler for a specific payload type from the server.
+     */
+    <T> void registerClientHandler(SyncPayloadType<T> type, BiConsumer<Player, T> handler);
+
+    /**
+     * Registers a handler for a specific payload type from the client.
+     */
+    <T> void registerServerHandler(SyncPayloadType<T> type, BiConsumer<Player, T> handler);
+
+    record SyncPayloadType<T>(Identifier id, StreamCodec<RegistryFriendlyByteBuf, T> codec) {}
+}

--- a/common/src/main/java/net/creeperhost/polylib/containers/network/PolyContainerSyncProtocol.java
+++ b/common/src/main/java/net/creeperhost/polylib/containers/network/PolyContainerSyncProtocol.java
@@ -1,0 +1,77 @@
+package net.creeperhost.polylib.containers.network;
+
+import net.creeperhost.polylib.containers.ModularGuiContainerMenu;
+import net.creeperhost.polylib.network.PolyLibNetwork;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.player.Player;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+public class PolyContainerSyncProtocol implements ContainerSyncProtocol {
+
+    private final ModularGuiContainerMenu container;
+    private final Map<String, BiConsumer<Player, ?>> clientHandlers = new HashMap<>();
+    private final Map<String, BiConsumer<Player, ?>> serverHandlers = new HashMap<>();
+    private final Map<String, SyncPayloadType<?>> types = new HashMap<>();
+
+    public PolyContainerSyncProtocol(ModularGuiContainerMenu container) {
+        this.container = container;
+    }
+
+    @Override
+    public <T> void sendToClient(ServerPlayer player, int containerId, SyncPayloadType<T> type, T payload) {
+        PolyLibNetwork.sendContainerPacketToClient(player, buf -> {
+            buf.writeByte(containerId);
+            buf.writeByte(254); // Special ID for protocol routing
+            buf.writeUtf(type.id().toString());
+            type.codec().encode(buf, payload);
+        });
+    }
+
+    @Override
+    public <T> void sendToServer(int containerId, SyncPayloadType<T> type, T payload) {
+        PolyLibNetwork.sendContainerPacketToServer(container.inventory.player.registryAccess(), buf -> {
+            buf.writeByte(containerId);
+            buf.writeByte(254);
+            buf.writeUtf(type.id().toString());
+            type.codec().encode(buf, payload);
+        });
+    }
+
+    @Override
+    public <T> void registerClientHandler(SyncPayloadType<T> type, BiConsumer<Player, T> handler) {
+        clientHandlers.put(type.id().toString(), handler);
+        types.put(type.id().toString(), type);
+    }
+
+    @Override
+    public <T> void registerServerHandler(SyncPayloadType<T> type, BiConsumer<Player, T> handler) {
+        serverHandlers.put(type.id().toString(), handler);
+        types.put(type.id().toString(), type);
+    }
+
+    @SuppressWarnings("unchecked")
+    public void handleClientPacket(Player player, RegistryFriendlyByteBuf buf) {
+        String id = buf.readUtf();
+        SyncPayloadType<?> type = types.get(id);
+        BiConsumer<Player, Object> handler = (BiConsumer<Player, Object>) clientHandlers.get(id);
+        if (type != null && handler != null) {
+            Object payload = type.codec().decode(buf);
+            handler.accept(player, payload);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public void handleServerPacket(Player player, RegistryFriendlyByteBuf buf) {
+        String id = buf.readUtf();
+        SyncPayloadType<?> type = types.get(id);
+        BiConsumer<Player, Object> handler = (BiConsumer<Player, Object>) serverHandlers.get(id);
+        if (type != null && handler != null) {
+            Object payload = type.codec().decode(buf);
+            handler.accept(player, payload);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a network-level container synchronisation protocol for `ModularGuiContainerMenu`.

### Changes
- `ContainerSyncProtocol` — common interface/contract for container data synchronisation
- `PolyContainerSyncProtocol` — PolyLib's default implementation
- `ModularGuiContainerMenu` — wired up to the new sync protocol

### Notes
- No breaking changes to existing container APIs