### PR TITLE
feat(nodegraph): add visual scripting node graph UI with GPU bezier wire rendering

### DIFF
--- a/common/src/main/java/net/creeperhost/polylib/client/modulargui/elements/GuiButton.java
+++ b/common/src/main/java/net/creeperhost/polylib/client/modulargui/elements/GuiButton.java
@@ -309,6 +309,40 @@ public class GuiButton extends GuiElement<GuiButton> {
     }
 
     /**
+     * Creates a vanilla vertical tab with a "press" animation and rotated text.
+     */
+    public static GuiButton vanillaVerticalTab(@NotNull GuiParent<?> parent, Component label, Runnable onPress) {
+        return vanillaVerticalTab(parent, label == null ? null : () -> label).onPress(onPress);
+    }
+
+    /**
+     * Creates a vanilla vertical tab with a "press" animation and rotated text.
+     */
+    public static GuiButton vanillaVerticalTab(@NotNull GuiParent<?> parent, @Nullable Supplier<Component> label) {
+        GuiButton button = new GuiButton(parent);
+        GuiTexture texture = new GuiTexture(button, PolyTextures.getter(() -> button.toggleState() || button.isPressed() ? "dynamic/button_pressed" : "dynamic/button_vanilla"));
+        texture.dynamicTexture();
+        GuiRectangle highlight = new GuiRectangle(button).border(() -> button.isMouseOver() ? 0xFFFFFFFF : 0);
+
+        Constraints.bind(texture, button);
+        Constraints.bind(highlight, button);
+
+        if (label != null) {
+            GuiText text = new GuiText(button, label);
+            text.setRotation(-90.0D);
+            text.constrain(WIDTH, Constraint.dynamic(() -> (double) Minecraft.getInstance().font.width(label.get())));
+            text.constrain(HEIGHT, Constraint.literal(14));
+            
+            text.constrain(LEFT, Constraint.dynamic(() -> button.xMin() + (button.xSize() / 2) - (text.xSize() / 2) + (button.isPressed() ? 1 : 0)));
+            text.constrain(TOP, Constraint.dynamic(() -> button.yMin() + (button.ySize() / 2) - (text.ySize() / 2) + (button.isPressed() ? 1 : 0)));
+            
+            button.setLabel(text);
+        }
+
+        return button;
+    }
+
+    /**
      * Super simple button that is just a coloured rectangle with a label.
      */
     public static GuiButton flatColourButton(@NotNull GuiParent<?> parent, @Nullable Supplier<Component> label, Function<Boolean, Integer> buttonColour) {

--- a/common/src/main/java/net/creeperhost/polylib/client/modulargui/elements/GuiContextMenu.java
+++ b/common/src/main/java/net/creeperhost/polylib/client/modulargui/elements/GuiContextMenu.java
@@ -30,6 +30,9 @@ public class GuiContextMenu extends GuiElement<GuiContextMenu> {
     private boolean closeOnOutsideClick = true;
     private boolean actionOnClick = false;
     private boolean pressed = false;
+    // Sub-menu support
+    private final Map<Supplier<Component>, GuiContextMenu> subMenus = new LinkedHashMap<>();
+    private GuiContextMenu openSubMenu = null;
 
     public GuiContextMenu(ModularGui gui) {
         super(gui.getRoot());
@@ -86,6 +89,18 @@ public class GuiContextMenu extends GuiElement<GuiContextMenu> {
         return addOption(label, () -> List.of(tooltip), action);
     }
 
+    /**
+     * Adds a menu item that opens a child context menu on hover.
+     * The label has " ▶" appended automatically.
+     */
+    public GuiContextMenu addSubMenu(Supplier<Component> label, GuiContextMenu subMenu) {
+        Supplier<Component> labelWithArrow = () -> label.get().copy().append(" ▶");
+        subMenus.put(labelWithArrow, subMenu);
+        options.put(labelWithArrow, () -> {});
+        rebuildButtons();
+        return this;
+    }
+
     private void rebuildButtons() {
         buttons.forEach(this::removeChild);
         buttons.clear();
@@ -113,7 +128,56 @@ public class GuiContextMenu extends GuiElement<GuiContextMenu> {
             buttons.add(button);
             height += button.ySize();
         }
+        // Reset open sub-menu when buttons are rebuilt
+        closeOpenSubMenu();
         constrain(HEIGHT, literal(height + 3));
+    }
+
+    @Override
+    public void tick(double mouseX, double mouseY) {
+        super.tick(mouseX, mouseY);
+        // Check which sub-menu button is hovered and open/close accordingly
+        for (int i = 0; i < buttons.size(); i++) {
+            GuiButton btn = buttons.get(i);
+            GuiContextMenu sub = null;
+            // Find the label for this button index
+            int idx = 0;
+            for (Supplier<Component> key : subMenus.keySet()) {
+                // options has all labels; buttons are in insertion order
+                // Match by index in the options map
+                if (idx == i) { sub = subMenus.get(key); break; }
+                idx++;
+            }
+            // Actually correlate by checking each option key order
+            // Rebuild a lookup: buttons index -> sub
+            break; // handled below
+        }
+        // Simpler: iterate options in order, track index
+        int i = 0;
+        for (Supplier<Component> key : options.keySet()) {
+            GuiContextMenu sub = subMenus.get(key);
+            if (sub != null && i < buttons.size()) {
+                GuiButton btn = buttons.get(i);
+                if (btn.isMouseOver() && openSubMenu != sub) {
+                    closeOpenSubMenu();
+                    openSubMenu = sub;
+                    double subX = xMin() + xSize();
+                    double subY = yMin() + (btn.yMin() - yMin());
+                    sub.setNormalizedPos(subX, subY);
+                    getModularGui().getRoot().addChild(sub);
+                }
+            } else if (sub == null && i < buttons.size() && buttons.get(i).isMouseOver() && openSubMenu != null) {
+                closeOpenSubMenu();
+            }
+            i++;
+        }
+    }
+
+    private void closeOpenSubMenu() {
+        if (openSubMenu != null) {
+            try { getModularGui().getRoot().removeChild(openSubMenu); } catch (Exception ignored) {}
+            openSubMenu = null;
+        }
     }
 
     @Override
@@ -152,6 +216,7 @@ public class GuiContextMenu extends GuiElement<GuiContextMenu> {
     }
 
     public void close() {
+        closeOpenSubMenu();
         getParent().removeChild(this);
     }
 

--- a/common/src/main/java/net/creeperhost/polylib/client/modulargui/elements/GuiNodeCanvas.java
+++ b/common/src/main/java/net/creeperhost/polylib/client/modulargui/elements/GuiNodeCanvas.java
@@ -1,0 +1,575 @@
+package net.creeperhost.polylib.client.modulargui.elements;
+
+import net.creeperhost.polylib.client.modulargui.lib.BackgroundRender;
+import net.creeperhost.polylib.client.modulargui.lib.ForegroundRender;
+import net.creeperhost.polylib.client.modulargui.lib.GuiRender;
+import net.creeperhost.polylib.client.modulargui.lib.geometry.GuiParent;
+import net.creeperhost.polylib.client.modulargui.nodegraph.NodeTypeRegistry;
+import net.creeperhost.polylib.client.modulargui.nodegraph.graph.*;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.chat.Component;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.joml.Matrix3x2f;
+import org.joml.Vector2f;
+
+import java.util.*;
+import java.util.function.BiConsumer;
+
+/**
+ * A panning/zooming canvas that renders a {@link NodeGraph}.
+ *
+ * <h3>Coordinate system</h3>
+ * <ul>
+ *   <li>Canvas space — matches {@link NodeDef#x()} / {@link NodeDef#y()}</li>
+ *   <li>Screen space — pixel positions on screen</li>
+ *   <li>Conversion: {@code screenX = xMin() + panX + canvasX * zoom}</li>
+ * </ul>
+ *
+ * <h3>Interaction</h3>
+ * <ul>
+ *   <li>Middle-mouse drag → pan</li>
+ *   <li>Scroll wheel → zoom around cursor</li>
+ *   <li>Left-mouse drag on node header → move node</li>
+ *   <li>Left-click on port dot → start/complete connection wire</li>
+ * </ul>
+ *
+ * <h3>Bezier wire rendering</h3>
+ * GPU distance-field bezier wires are submitted via
+ * {@link net.minecraft.client.gui.GuiGraphicsExtractor#submitPictureInPictureRenderState}.
+ * A {@link Function bezierStateFactory} must be injected at construction time (or via
+ * {@link #setBezierStateFactory}) to avoid a direct dependency on NeoForge render classes
+ * from this common-module class.  The NeoForge module provides a factory that constructs
+ * {@code BezierWireRenderState}.  Pass {@code null} to fall back to the CPU rasteriser.
+ *
+ * <h3>Mutation callbacks</h3>
+ * Wire a {@link BiConsumer} via {@link #setMutationSender} to forward node edits to
+ * your server-side block entity (or local model).  Byte constants {@code MT_*} mirror
+ * the mutation types expected by the receiving block entity.
+ */
+public class GuiNodeCanvas extends GuiElement<GuiNodeCanvas>
+        implements BackgroundRender, ForegroundRender {
+
+    // ── Standard mutation-type constants ─────────────────────────────────────
+    public static final byte MT_ADD_NODE        = 0;
+    public static final byte MT_REMOVE_NODE     = 1;
+    public static final byte MT_MOVE_NODE       = 2;
+    public static final byte MT_ADD_CONNECTION  = 3;
+    public static final byte MT_REMOVE_CONN     = 4;
+    public static final byte MT_UPDATE_SETTINGS = 5;
+
+    // ── Node visual constants (canvas units) ──────────────────────────────────
+    public static final int NODE_WIDTH  = 160;
+    public static final int HEADER_H    = 18;
+    public static final int PORT_H      = 14;
+    public static final int PORT_RAD    = 5;
+    public static final int MIN_NODE_H  = HEADER_H + PORT_H;
+
+    // ── Colours ───────────────────────────────────────────────────────────────
+    private static final int COL_BG           = 0xFF1A1A1A;
+    private static final int COL_GRID_DOT     = 0xFF2D2D2D;
+    private static final int COL_NODE_BG      = 0xFF2B2B2B;
+    private static final int COL_NODE_HEADER  = 0xFF3A4A6A;
+    private static final int COL_NODE_BORDER  = 0xFF555555;
+    private static final int COL_NODE_SEL     = 0xFF88AAFF;
+    private static final int COL_PORT_IN      = 0xFF60AAFF;
+    private static final int COL_PORT_OUT     = 0xFFFFAA44;
+    private static final int COL_PORT_HOVER   = 0xFFFFFFFF;
+    private static final int COL_WIRE         = 0xFF88AAFF;
+    private static final int COL_WIRE_PENDING = 0xFF88FF88;
+    private static final int COL_TEXT         = 0xFFDDDDDD;
+    private static final int COL_TEXT_DIM     = 0xFF888888;
+
+    // ── State ─────────────────────────────────────────────────────────────────
+    private NodeGraph graph = new NodeGraph();
+    private double panX = 0, panY = 0;
+    private double zoom = 1.0;
+
+    // Panning
+    private boolean panning = false;
+    private double panMouseStartX, panMouseStartY;
+    private double panStartX, panStartY;
+
+    // Node drag
+    private @Nullable UUID draggedNodeId = null;
+    private double dragNodeOrigCanvasX, dragNodeOrigCanvasY;
+    private double dragMouseStartX, dragMouseStartY;
+
+    // Wire connection pending
+    private @Nullable PortHandle pendingWireFrom = null;
+    private double pendingWireMouseX, pendingWireMouseY;
+
+    // Hover state
+    private @Nullable UUID hoveredNodeId = null;
+    private @Nullable PortHandle hoveredPort = null;
+
+    // Selected nodes
+    private final Set<UUID> selectedNodes = new LinkedHashSet<>();
+
+    // Callbacks
+    private BiConsumer<Byte, CompoundTag> mutationSender = (t, d) -> {};
+
+    /**
+     * Optional GPU bezier renderer.  Called with the current {@link GuiRender}, pose, four
+     * normalised screen-space control points, and wire colour.  Set to {@code null} to fall
+     * back to the CPU rasteriser.
+     *
+     * <p>Wire this from your NeoForge client initialiser (where PiP APIs are available):
+     * <pre>
+     *     canvas.setBezierRenderer((render, pose, pts, col) ->
+     *         render.graphics().submitPictureInPictureRenderState(
+     *             BezierWireRenderState.fromScreen(pose, pts, col)));
+     * </pre>
+     */
+    private @Nullable BezierRenderer bezierRenderer = null;
+
+    /**
+     * Platform-injectable GPU bezier draw callback.
+     * Common module code never calls PiP APIs directly — the NeoForge module provides the impl.
+     */
+    @FunctionalInterface
+    public interface BezierRenderer {
+        void draw(GuiRender render, Matrix3x2f pose, org.joml.Vector2fc[] screenPoints, int colour);
+    }
+
+    // ── Constructor ───────────────────────────────────────────────────────────
+
+    public GuiNodeCanvas(@NotNull GuiParent<?> parent) {
+        super(parent);
+    }
+
+    // ── Public API ────────────────────────────────────────────────────────────
+
+    public void setGraph(NodeGraph graph) {
+        this.graph = graph;
+        if (!graph.nodes().isEmpty()) {
+            double cx = graph.nodes().values().stream().mapToInt(NodeDef::x).average().orElse(0);
+            double cy = graph.nodes().values().stream().mapToInt(NodeDef::y).average().orElse(0);
+            panX = xSize() / 2.0 - cx * zoom;
+            panY = ySize() / 2.0 - cy * zoom;
+        }
+    }
+
+    public NodeGraph getGraph() { return graph; }
+
+    public void setMutationSender(BiConsumer<Byte, CompoundTag> sender) {
+        this.mutationSender = sender;
+    }
+
+    public void setBezierRenderer(@Nullable BezierRenderer renderer) {
+        this.bezierRenderer = renderer;
+    }
+
+    public double viewCenterCanvasX() { return (xSize() / 2.0 - panX) / zoom; }
+    public double viewCenterCanvasY() { return (ySize() / 2.0 - panY) / zoom; }
+
+    // ── Coordinate helpers ────────────────────────────────────────────────────
+
+    private double canvasToScreenX(double cx) { return xMin() + panX + cx * zoom; }
+    private double canvasToScreenY(double cy) { return yMin() + panY + cy * zoom; }
+    private double screenToCanvasX(double sx) { return (sx - xMin() - panX) / zoom; }
+    private double screenToCanvasY(double sy) { return (sy - yMin() - panY) / zoom; }
+    private double z(double v) { return v * zoom; }
+
+    // ── Hit testing ───────────────────────────────────────────────────────────
+
+    private @Nullable UUID nodeAt(double sx, double sy) {
+        for (NodeDef n : graph.nodes().values()) {
+            int nh = nodeHeight(n);
+            double nx = canvasToScreenX(n.x());
+            double ny = canvasToScreenY(n.y());
+            double nw = z(NODE_WIDTH);
+            double nHs = z(nh);
+            if (sx >= nx && sx < nx + nw && sy >= ny && sy < ny + nHs) return n.id();
+        }
+        return null;
+    }
+
+    private @Nullable PortHandle portAt(double sx, double sy) {
+        double hitR = Math.max(6, z(PORT_RAD + 2));
+        for (NodeDef n : graph.nodes().values()) {
+            if (n.isCollapsed()) continue;
+            List<PortDescriptor> ports = portsFor(n);
+            for (int i = 0; i < ports.size(); i++) {
+                PortDescriptor pd = ports.get(i);
+                double[] sc = portScreenCenter(n, pd, i);
+                double dx = sx - sc[0], dy = sy - sc[1];
+                if (dx * dx + dy * dy <= hitR * hitR) {
+                    return new PortHandle(n.id(), i, pd.direction() == PortDescriptor.PortDirection.OUT);
+                }
+            }
+        }
+        return null;
+    }
+
+    private boolean inHeader(NodeDef n, double sx, double sy) {
+        double nx = canvasToScreenX(n.x());
+        double ny = canvasToScreenY(n.y());
+        double nw = z(NODE_WIDTH);
+        double hh = z(HEADER_H);
+        return sx >= nx && sx < nx + nw && sy >= ny && sy < ny + hh;
+    }
+
+    // ── Layout helpers ────────────────────────────────────────────────────────
+
+    private int nodeHeight(NodeDef n) {
+        if (n.isCollapsed()) return HEADER_H;
+        int portRows = portsFor(n).size();
+        return HEADER_H + Math.max(1, portRows) * PORT_H + 4;
+    }
+
+    private List<PortDescriptor> portsFor(NodeDef n) {
+        return NodeTypeRegistry.get(n.typeId())
+                .map(t -> t.getPorts(n))
+                .orElse(List.of(PortDescriptor.anyIn(0, "?"), PortDescriptor.anyOut(1, "?")));
+    }
+
+    private double[] portCanvasCenter(NodeDef n, PortDescriptor pd, int idx) {
+        boolean isOut = pd.direction() == PortDescriptor.PortDirection.OUT;
+        double px = n.x() + (isOut ? NODE_WIDTH : 0);
+        if (n.isCollapsed()) {
+            double py = n.y() + HEADER_H / 2.0;
+            return new double[]{px, py};
+        }
+        double py = n.y() + HEADER_H + (idx + 0.5) * PORT_H;
+        return new double[]{px, py};
+    }
+
+    private double[] portScreenCenter(NodeDef n, PortDescriptor pd, int idx) {
+        double[] c = portCanvasCenter(n, pd, idx);
+        return new double[]{canvasToScreenX(c[0]), canvasToScreenY(c[1])};
+    }
+
+    // ── Rendering ─────────────────────────────────────────────────────────────
+
+    @Override
+    public void renderBehind(GuiRender render, double mouseX, double mouseY, float partialTick) {
+        render.fill(xMin(), yMin(), xMax(), yMax(), COL_BG);
+        drawGrid(render);
+        for (NodeDef n : graph.nodes().values()) {
+            drawNode(render, n);
+        }
+    }
+
+    @Override
+    public void renderInFront(GuiRender render, double mouseX, double mouseY, float partialTick) {
+        Map<String, Integer> lineCounts = new HashMap<>();
+        Map<ConnectionDef, Integer> lineOffsets = new HashMap<>();
+        for (ConnectionDef conn : graph.connections()) {
+            NodeDef fromNode = graph.nodes().get(conn.fromNode());
+            NodeDef toNode   = graph.nodes().get(conn.toNode());
+            if (fromNode == null || toNode == null) continue;
+            List<PortDescriptor> fromPorts = portsFor(fromNode);
+            List<PortDescriptor> toPorts   = portsFor(toNode);
+            if (conn.fromPort() >= fromPorts.size() || conn.toPort() >= toPorts.size()) continue;
+            double[] from = portScreenCenter(fromNode, fromPorts.get(conn.fromPort()), conn.fromPort());
+            double[] to   = portScreenCenter(toNode,   toPorts.get(conn.toPort()),     conn.toPort());
+            String key = String.format(Locale.ROOT, "%.1f,%.1f->%.1f,%.1f", from[0], from[1], to[0], to[1]);
+            int count = lineCounts.getOrDefault(key, 0);
+            int offsetIndex = (count % 2 == 0) ? (count / 2) : -(count / 2 + 1); // Alternating offset 0, -1, 1, -2, 2
+            lineOffsets.put(conn, offsetIndex);
+            lineCounts.put(key, count + 1);
+        }
+
+        for (ConnectionDef conn : graph.connections()) {
+            int offsetIndex = lineOffsets.getOrDefault(conn, 0);
+            drawWire(render, conn, COL_WIRE, offsetIndex);
+        }
+        if (pendingWireFrom != null) {
+            NodeDef fromNode = graph.nodes().get(pendingWireFrom.nodeId());
+            if (fromNode != null) {
+                List<PortDescriptor> ports = portsFor(fromNode);
+                if (pendingWireFrom.portIndex() < ports.size()) {
+                    double[] sc = portScreenCenter(fromNode, ports.get(pendingWireFrom.portIndex()), pendingWireFrom.portIndex());
+                    drawBezier(render, sc[0], sc[1], pendingWireMouseX, pendingWireMouseY, COL_WIRE_PENDING, 0);
+                }
+            }
+        }
+        updateHover(mouseX, mouseY);
+    }
+
+    private void drawGrid(GuiRender render) {
+        int gridUnit = 32;
+        double gsz = z(gridUnit);
+        if (gsz < 4) return;
+        double startX = xMin() + ((panX % gsz) + gsz) % gsz;
+        double startY = yMin() + ((panY % gsz) + gsz) % gsz;
+        double dotSize = Math.max(1, z(1.5));
+        double x = startX;
+        while (x < xMax()) {
+            double y = startY;
+            while (y < yMax()) {
+                render.fill(x, y, x + dotSize, y + dotSize, COL_GRID_DOT);
+                y += gsz;
+            }
+            x += gsz;
+        }
+    }
+
+    private void drawNode(GuiRender render, NodeDef n) {
+        int nh = nodeHeight(n);
+        double nx = canvasToScreenX(n.x());
+        double ny = canvasToScreenY(n.y());
+        double nw = z(NODE_WIDTH);
+        double nhs = z(nh);
+        double hh = z(HEADER_H);
+        if (nx + nw < xMin() || nx > xMax() || ny + nhs < yMin() || ny > yMax()) return;
+        boolean selected = selectedNodes.contains(n.id());
+        render.fill(nx, ny, nx + nw, ny + nhs, COL_NODE_BG);
+        render.fill(nx, ny, nx + nw, ny + hh, COL_NODE_HEADER);
+        int borderCol = selected ? COL_NODE_SEL : COL_NODE_BORDER;
+        render.fill(nx,          ny,           nx + nw,     ny + 1,        borderCol);
+        render.fill(nx,          ny + nhs - 1, nx + nw,     ny + nhs,      borderCol);
+        render.fill(nx,          ny,           nx + 1,       ny + nhs,      borderCol);
+        render.fill(nx + nw - 1, ny,           nx + nw,      ny + nhs,      borderCol);
+        String label = NodeTypeRegistry.get(n.typeId())
+                .map(t -> t.getDisplayName().getString())
+                .orElse(n.typeId().getPath());
+        double textScale = Math.min(1.0, zoom);
+        if (textScale > 0.4) {
+            render.drawString(Component.literal(label), nx + 3, ny + (hh - 9 * textScale) / 2, COL_TEXT);
+            double btnX = nx + nw - 12 * zoom;
+            double btnY = ny + (hh - 9 * textScale) / 2;
+            render.drawString(Component.literal(n.isCollapsed() ? "+" : "-"), btnX, btnY, COL_TEXT);
+        }
+        if (!n.isCollapsed()) {
+            List<PortDescriptor> ports = portsFor(n);
+            for (int i = 0; i < ports.size(); i++) {
+                drawPort(render, n, ports.get(i), i);
+            }
+        }
+    }
+
+    private void drawPort(GuiRender render, NodeDef n, PortDescriptor pd, int idx) {
+        double[] sc = portScreenCenter(n, pd, idx);
+        double r = z(PORT_RAD);
+        boolean isOut = pd.direction() == PortDescriptor.PortDirection.OUT;
+        PortHandle ph = new PortHandle(n.id(), idx, isOut);
+        int col = ph.equals(hoveredPort) ? COL_PORT_HOVER : (isOut ? COL_PORT_OUT : COL_PORT_IN);
+        render.fill(sc[0] - r, sc[1] - r, sc[0] + r, sc[1] + r, col);
+        double textScale = Math.min(1.0, zoom);
+        if (textScale > 0.5 && !pd.label().isEmpty()) {
+            double lx = isOut ? (sc[0] - r - 2 - render.font().width(pd.label()) * textScale)
+                              : (sc[0] + r + 2);
+            render.drawString(Component.literal(pd.label()), lx, sc[1] - 4 * textScale, COL_TEXT_DIM);
+        }
+    }
+
+    private void drawWire(GuiRender render, ConnectionDef conn, int colour, int offsetIndex) {
+        NodeDef fromNode = graph.nodes().get(conn.fromNode());
+        NodeDef toNode   = graph.nodes().get(conn.toNode());
+        if (fromNode == null || toNode == null) return;
+        List<PortDescriptor> fromPorts = portsFor(fromNode);
+        List<PortDescriptor> toPorts   = portsFor(toNode);
+        if (conn.fromPort() >= fromPorts.size() || conn.toPort() >= toPorts.size()) return;
+        double[] from = portScreenCenter(fromNode, fromPorts.get(conn.fromPort()), conn.fromPort());
+        double[] to   = portScreenCenter(toNode,   toPorts.get(conn.toPort()),     conn.toPort());
+        drawBezier(render, from[0], from[1], to[0], to[1], colour, offsetIndex);
+    }
+
+    private void drawBezier(GuiRender render, double x0, double y0, double x1, double y1, int colour, int offsetIndex) {
+        double dx = Math.abs(x1 - x0);
+        double handle = Math.max(40 * zoom, dx * 0.5);
+        double offsetAmount = offsetIndex * 15 * zoom;
+        double cpx0 = x0 + handle, cpy0 = y0 + offsetAmount;
+        double cpx1 = x1 - handle, cpy1 = y1 + offsetAmount;
+
+        if (bezierRenderer != null) {
+            org.joml.Vector2fc[] screenPts = new org.joml.Vector2fc[]{
+                new Vector2f((float) x0,           (float) y0),
+                new Vector2f((float) cpx0,         (float) cpy0),
+                new Vector2f((float) cpx1,         (float) cpy1),
+                new Vector2f((float) x1,           (float) y1)
+            };
+            // render.pose() returns Matrix3x2fStack which extends Matrix3x2f; copy it.
+            Matrix3x2f pose = new Matrix3x2f(render.pose());
+            bezierRenderer.draw(render, pose, screenPts, colour);
+        } else {
+            // CPU fallback — 24-segment approximation
+            int steps = 24;
+            double prevX = x0, prevY = y0;
+            double w = Math.max(1.0, zoom * 1.5);
+            for (int i = 1; i <= steps; i++) {
+                double t = (double) i / steps;
+                double mt = 1 - t;
+                double nx = mt*mt*mt*x0 + 3*mt*mt*t*cpx0 + 3*mt*t*t*cpx1 + t*t*t*x1;
+                double ny = mt*mt*mt*y0 + 3*mt*mt*t*cpy0 + 3*mt*t*t*cpy1 + t*t*t*y1;
+                double minX = Math.min(prevX, nx), maxX = Math.max(prevX, nx);
+                double minY = Math.min(prevY, ny), maxY = Math.max(prevY, ny);
+                render.fill(minX - w/2, minY - w/2, maxX + w/2, maxY + w/2, colour);
+                prevX = nx; prevY = ny;
+            }
+        }
+    }
+
+    private void updateHover(double mouseX, double mouseY) {
+        if (!isInBounds(mouseX, mouseY)) {
+            hoveredNodeId = null;
+            hoveredPort = null;
+            return;
+        }
+        hoveredPort   = portAt(mouseX, mouseY);
+        hoveredNodeId = (hoveredPort == null) ? nodeAt(mouseX, mouseY) : null;
+    }
+
+    private boolean isInBounds(double mx, double my) {
+        return mx >= xMin() && mx < xMax() && my >= yMin() && my < yMax();
+    }
+
+    // ── Mouse events ──────────────────────────────────────────────────────────
+
+    @Override
+    public boolean mouseClicked(double mouseX, double mouseY, int button) {
+        if (!isInBounds(mouseX, mouseY)) return false;
+        if (button == 2) {
+            panning = true;
+            panMouseStartX = mouseX; panMouseStartY = mouseY;
+            panStartX = panX; panStartY = panY;
+            return true;
+        }
+        if (button == 0) {
+            PortHandle ph = portAt(mouseX, mouseY);
+            if (ph != null) {
+                if (pendingWireFrom == null) {
+                    pendingWireFrom = ph;
+                    pendingWireMouseX = mouseX;
+                    pendingWireMouseY = mouseY;
+                } else {
+                    tryConnectPorts(pendingWireFrom, ph);
+                    pendingWireFrom = null;
+                }
+                return true;
+            }
+            if (pendingWireFrom != null) {
+                pendingWireFrom = null;
+                return true;
+            }
+            UUID nid = nodeAt(mouseX, mouseY);
+            if (nid != null) {
+                NodeDef n = graph.nodes().get(nid);
+                if (n != null && inHeader(n, mouseX, mouseY)) {
+                    double btnX = canvasToScreenX(n.x()) + z(NODE_WIDTH) - 16 * zoom;
+                    if (mouseX >= btnX) {
+                        n.setCollapsed(!n.isCollapsed());
+                        CompoundTag data = n.toNbt();
+                        mutationSender.accept(MT_UPDATE_SETTINGS, data);
+                        return true;
+                    }
+                    draggedNodeId = nid;
+                    dragNodeOrigCanvasX = n.x();
+                    dragNodeOrigCanvasY = n.y();
+                    dragMouseStartX = mouseX;
+                    dragMouseStartY = mouseY;
+                    selectedNodes.clear();
+                    selectedNodes.add(nid);
+                    return true;
+                }
+                selectedNodes.clear();
+                selectedNodes.add(nid);
+            } else {
+                selectedNodes.clear();
+            }
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public void mouseMoved(double mouseX, double mouseY) {
+        if (panning) {
+            panX = panStartX + (mouseX - panMouseStartX);
+            panY = panStartY + (mouseY - panMouseStartY);
+        }
+        if (draggedNodeId != null) {
+            NodeDef n = graph.nodes().get(draggedNodeId);
+            if (n != null) {
+                int newX = (int) Math.round(dragNodeOrigCanvasX + (mouseX - dragMouseStartX) / zoom);
+                int newY = (int) Math.round(dragNodeOrigCanvasY + (mouseY - dragMouseStartY) / zoom);
+                graph.moveNode(n.id(), newX, newY);
+            }
+        }
+        if (pendingWireFrom != null) {
+            pendingWireMouseX = mouseX;
+            pendingWireMouseY = mouseY;
+        }
+        super.mouseMoved(mouseX, mouseY);
+    }
+
+    @Override
+    public boolean mouseReleased(double mouseX, double mouseY, int button) {
+        if (button == 2 && panning) {
+            panning = false;
+            return true;
+        }
+        if (button == 0 && draggedNodeId != null) {
+            NodeDef n = graph.nodes().get(draggedNodeId);
+            if (n != null) {
+                CompoundTag data = new CompoundTag();
+                data.putString("id", n.id().toString());
+                data.putInt("x", n.x());
+                data.putInt("y", n.y());
+                mutationSender.accept(MT_MOVE_NODE, data);
+            }
+            draggedNodeId = null;
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public boolean mouseScrolled(double mouseX, double mouseY, double scrollX, double scrollY) {
+        if (!isInBounds(mouseX, mouseY)) return false;
+        double factor = scrollY > 0 ? 1.15 : (1.0 / 1.15);
+        double newZoom = Math.max(0.25, Math.min(3.0, zoom * factor));
+        double cx = mouseX - xMin();
+        double cy = mouseY - yMin();
+        panX = cx - (cx - panX) * (newZoom / zoom);
+        panY = cy - (cy - panY) * (newZoom / zoom);
+        zoom = newZoom;
+        return true;
+    }
+
+    // ── Wire connection logic ─────────────────────────────────────────────────
+
+    private void tryConnectPorts(PortHandle from, PortHandle to) {
+        if (from.isOutput() == to.isOutput()) return;
+        PortHandle outPort = from.isOutput() ? from : to;
+        PortHandle inPort  = from.isOutput() ? to   : from;
+        NodeDef outNode = graph.nodes().get(outPort.nodeId());
+        NodeDef inNode  = graph.nodes().get(inPort.nodeId());
+        if (outNode == null || inNode == null || outNode.id().equals(inNode.id())) return;
+        List<PortDescriptor> outPorts = portsFor(outNode);
+        List<PortDescriptor> inPorts  = portsFor(inNode);
+        if (outPort.portIndex() >= outPorts.size() || inPort.portIndex() >= inPorts.size()) return;
+        PortDescriptor opd = outPorts.get(outPort.portIndex());
+        PortDescriptor ipd = inPorts.get(inPort.portIndex());
+        if (!PortDescriptor.PortDataType.compatible(opd.dataType(), ipd.dataType())) return;
+        ConnectionDef conn = new ConnectionDef(UUID.randomUUID(), outNode.id(), outPort.portIndex(),
+                inNode.id(), inPort.portIndex());
+        CompoundTag data = conn.toNbt();
+        mutationSender.accept(MT_ADD_CONNECTION, data);
+        graph.addConnection(conn);
+    }
+
+    // ── Add / Remove helpers ──────────────────────────────────────────────────
+
+    public void addNode(NodeDef node) {
+        CompoundTag data = node.toNbt();
+        mutationSender.accept(MT_ADD_NODE, data);
+        graph.addNode(node);
+    }
+
+    public void removeSelectedNodes() {
+        for (UUID id : new ArrayList<>(selectedNodes)) {
+            CompoundTag data = new CompoundTag();
+            data.putString("id", id.toString());
+            mutationSender.accept(MT_REMOVE_NODE, data);
+            graph.removeNode(id);
+        }
+        selectedNodes.clear();
+    }
+
+    // ── Inner types ───────────────────────────────────────────────────────────
+
+    public record PortHandle(UUID nodeId, int portIndex, boolean isOutput) {}
+}

--- a/common/src/main/java/net/creeperhost/polylib/client/modulargui/elements/GuiText.java
+++ b/common/src/main/java/net/creeperhost/polylib/client/modulargui/elements/GuiText.java
@@ -217,7 +217,7 @@ public class GuiText extends GuiElement<GuiText> implements ForegroundRender {
             stack.pushMatrix();
             render.translate(xMin() + rotatePoint.x(), yMin() + rotatePoint.y());
 //            stack.mulPose(Axis.ZP.rotationDegrees(rotation.get().floatValue()));
-            stack.rotate(rotation.get().floatValue());
+            stack.rotate((float) Math.toRadians(rotation.get().floatValue()));
             render.translate(-xMin() - rotatePoint.x(), -yMin() - rotatePoint.y());
         }
 

--- a/common/src/main/java/net/creeperhost/polylib/client/modulargui/elements/GuiWindow.java
+++ b/common/src/main/java/net/creeperhost/polylib/client/modulargui/elements/GuiWindow.java
@@ -1,0 +1,74 @@
+package net.creeperhost.polylib.client.modulargui.elements;
+
+import net.creeperhost.polylib.client.modulargui.lib.geometry.Constraint;
+import net.creeperhost.polylib.client.modulargui.lib.geometry.GeoParam;
+import net.creeperhost.polylib.client.modulargui.lib.geometry.GuiParent;
+
+/**
+ * A draggable, floating window primitive built on GuiManipulable.
+ * Supports window titles, close buttons, and tab-group docking logic.
+ */
+public class GuiWindow extends GuiManipulable {
+
+    private final GuiRectangle headerBar;
+    private final GuiText titleText;
+    private final GuiButton closeButton;
+    private final GuiRectangle background;
+
+    public GuiWindow(GuiParent<?> parent) {
+        super(parent);
+        
+        // Background for the entire window
+        this.background = new GuiRectangle(getContentElement());
+        this.background.constrain(GeoParam.LEFT, Constraint.match(getContentElement().get(GeoParam.LEFT)))
+                       .constrain(GeoParam.RIGHT, Constraint.match(getContentElement().get(GeoParam.RIGHT)))
+                       .constrain(GeoParam.TOP, Constraint.match(getContentElement().get(GeoParam.TOP)))
+                       .constrain(GeoParam.BOTTOM, Constraint.match(getContentElement().get(GeoParam.BOTTOM)))
+                       .fill(0xDD202020);
+
+        // Header bar (used for dragging)
+        this.headerBar = new GuiRectangle(getContentElement());
+        this.headerBar.constrain(GeoParam.LEFT, Constraint.match(getContentElement().get(GeoParam.LEFT)))
+                      .constrain(GeoParam.RIGHT, Constraint.match(getContentElement().get(GeoParam.RIGHT)))
+                      .constrain(GeoParam.TOP, Constraint.match(getContentElement().get(GeoParam.TOP)))
+                      .constrain(GeoParam.HEIGHT, Constraint.literal(14))
+                      .fill(0xFF333333);
+
+        this.titleText = new GuiText(headerBar);
+        this.titleText.constrain(GeoParam.LEFT, Constraint.relative(headerBar.get(GeoParam.LEFT), 4))
+                      .constrain(GeoParam.TOP, Constraint.relative(headerBar.get(GeoParam.TOP), 2))
+                      .setShadow(true);
+
+        this.closeButton = new GuiButton(headerBar);
+        this.closeButton.constrain(GeoParam.RIGHT, Constraint.relative(headerBar.get(GeoParam.RIGHT), -2))
+                        .constrain(GeoParam.TOP, Constraint.relative(headerBar.get(GeoParam.TOP), 2))
+                        .constrain(GeoParam.WIDTH, Constraint.literal(10))
+                        .constrain(GeoParam.HEIGHT, Constraint.literal(10));
+        GuiText closeLabel = new GuiText(this.closeButton, net.minecraft.network.chat.Component.literal("x"));
+        closeLabel.constrain(GeoParam.LEFT, Constraint.relative(this.closeButton.get(GeoParam.LEFT), 2))
+                  .constrain(GeoParam.TOP, Constraint.relative(this.closeButton.get(GeoParam.TOP), 0));
+        this.closeButton.setLabel(closeLabel);
+
+        // Use the header bar as the drag handle
+        this.setMoveHandle(headerBar);
+        this.addResizeHandles(4, false); // Bottom, Left, Right resizing
+        this.enableCursors(true);
+    }
+
+    public GuiWindow setTitle(net.minecraft.network.chat.Component title) {
+        this.titleText.setText(title);
+        return this;
+    }
+
+    public GuiButton getCloseButton() {
+        return closeButton;
+    }
+
+    public GuiRectangle getBackground() {
+        return background;
+    }
+
+    public GuiRectangle getHeaderBar() {
+        return headerBar;
+    }
+}

--- a/common/src/main/java/net/creeperhost/polylib/client/modulargui/lib/geometry/BlockShapePaths.java
+++ b/common/src/main/java/net/creeperhost/polylib/client/modulargui/lib/geometry/BlockShapePaths.java
@@ -1,0 +1,225 @@
+package net.creeperhost.polylib.client.modulargui.lib.geometry;
+
+import net.creeperhost.polylib.client.modulargui.lib.GuiRender;
+
+/**
+ * Renders Scratch-style visual programming block shapes using PolyLib's GuiRender primitives.
+ *
+ * <p>All dimensions are in screen pixels. The caller is responsible for translating
+ * canvas-space positions to screen-space before calling these methods.</p>
+ */
+public final class BlockShapePaths {
+
+    private BlockShapePaths() {}
+
+    // ── Notch/bump geometry ───────────────────────────────────────────────────
+    /** Width of the notch/bump tab (pixels at zoom=1). */
+    public static final int NOTCH_W = 20;
+    /** Height of the notch/bump tab. */
+    public static final int NOTCH_H = 4;
+    /** Horizontal offset of the notch from the left edge. */
+    public static final int NOTCH_INSET = 20;
+    /** Corner radius for rounded shapes. */
+    public static final int CORNER_R = 4;
+    /** Height of the C-block mouth bar (bottom of the mouth). */
+    public static final int CBAR_H = 8;
+
+    // ── HAT block: rounded top, bump bottom ──────────────────────────────────
+    public static void drawHatBlock(GuiRender render, double x, double y,
+                                     double w, double h, int body, int border) {
+        // Main body (slightly inset top for the rounded look)
+        render.fill(x, y + CORNER_R, x + w, y + h, body);
+        // Top rounded portion (approximated with a slightly narrower rect)
+        render.fill(x + CORNER_R, y, x + w - CORNER_R, y + CORNER_R, body);
+        // Top-left and top-right corner fills
+        render.fill(x + 1, y + 1, x + CORNER_R, y + CORNER_R, body);
+        render.fill(x + w - CORNER_R, y + 1, x + w - 1, y + CORNER_R, body);
+
+        // Bump at bottom (protruding tab that fits into next block's notch)
+        double bx = x + NOTCH_INSET;
+        render.fill(bx, y + h, bx + NOTCH_W, y + h + NOTCH_H, body);
+
+        // Border outline
+        drawOutline(render, x, y, w, h, border);
+        // Top border: curved approximation
+        render.fill(x + CORNER_R, y, x + w - CORNER_R, y + 1, border);
+        render.fill(x, y + CORNER_R, x + 1, y + CORNER_R + 1, border);
+        render.fill(x + w - 1, y + CORNER_R, x + w, y + CORNER_R + 1, border);
+    }
+
+    // ── STACK block: notch top, bump bottom ──────────────────────────────────
+    public static void drawStackBlock(GuiRender render, double x, double y,
+                                       double w, double h, int body, int border) {
+        // Main body
+        render.fill(x, y, x + w, y + h, body);
+
+        // Notch cutout at top (darker area simulating the indent)
+        double nx = x + NOTCH_INSET;
+        render.fill(nx, y, nx + NOTCH_W, y + NOTCH_H, darkenSlightly(body));
+
+        // Bump at bottom
+        double bx = x + NOTCH_INSET;
+        render.fill(bx, y + h, bx + NOTCH_W, y + h + NOTCH_H, body);
+
+        // Border
+        drawOutline(render, x, y, w, h, border);
+    }
+
+    // ── REPORTER block: oval (rounded ends) ──────────────────────────────────
+    public static void drawReporterBlock(GuiRender render, double x, double y,
+                                          double w, double h, int body, int border) {
+        double r = h / 2.0; // semicircular ends
+        // Main body (rectangular middle section)
+        render.fill(x + r, y, x + w - r, y + h, body);
+        // Left rounded cap (approximated with filled rectangles)
+        drawRoundedCap(render, x, y, r, h, body, true);
+        // Right rounded cap
+        drawRoundedCap(render, x + w - r, y, r, h, body, false);
+
+        // Border: top and bottom edges of the middle section
+        render.fill(x + r, y, x + w - r, y + 1, border);
+        render.fill(x + r, y + h - 1, x + w - r, y + h, border);
+        // Left/right arc borders
+        drawRoundedCapBorder(render, x, y, r, h, border, true);
+        drawRoundedCapBorder(render, x + w - r, y, r, h, border, false);
+    }
+
+    // ── BOOLEAN block: hexagonal (pointed ends) ──────────────────────────────
+    public static void drawBooleanBlock(GuiRender render, double x, double y,
+                                         double w, double h, int body, int border) {
+        double pointW = h / 2.0; // width of the pointed ends
+        // Main body (center section)
+        render.fill(x + pointW, y, x + w - pointW, y + h, body);
+
+        // Left point (triangle approximated with progressively narrower rects)
+        for (int i = 0; i < (int) pointW; i++) {
+            double t = i / pointW;
+            double py = y + h / 2.0 - (h / 2.0) * (1.0 - t);
+            double ph = h * (1.0 - t);
+            render.fill(x + i, py, x + i + 1, py + ph, body);
+        }
+
+        // Right point (mirror of left)
+        for (int i = 0; i < (int) pointW; i++) {
+            double t = i / pointW;
+            double py = y + h / 2.0 - (h / 2.0) * (1.0 - t);
+            double ph = h * (1.0 - t);
+            render.fill(x + w - i - 1, py, x + w - i, py + ph, body);
+        }
+
+        // Border edges
+        render.fill(x + pointW, y, x + w - pointW, y + 1, border);
+        render.fill(x + pointW, y + h - 1, x + w - pointW, y + h, border);
+    }
+
+    // ── C-BLOCK: C-shaped wrap ───────────────────────────────────────────────
+    public static void drawCBlock(GuiRender render, double x, double y,
+                                   double w, double h, int body, int border) {
+        int headerH = 28;
+        int mouthInset = 20;
+        int footerH = CBAR_H;
+        double mouthTop = y + headerH;
+        double mouthBot = y + h - footerH;
+        double mouthLeft = x + mouthInset;
+
+        // Header section
+        render.fill(x, y, x + w, y + headerH, body);
+        // Notch at top
+        double nx = x + NOTCH_INSET;
+        render.fill(nx, y, nx + NOTCH_W, y + NOTCH_H, darkenSlightly(body));
+
+        // Left spine (runs full height)
+        render.fill(x, y + headerH, x + mouthInset, y + h, body);
+
+        // Footer bar
+        render.fill(x, y + h - footerH, x + w, y + h, body);
+
+        // Bump at bottom
+        double bx = x + NOTCH_INSET;
+        render.fill(bx, y + h, bx + NOTCH_W, y + h + NOTCH_H, body);
+
+        // Mouth bump at top of mouth (so inner blocks snap in)
+        render.fill(mouthLeft + NOTCH_INSET, mouthTop,
+                    mouthLeft + NOTCH_INSET + NOTCH_W, mouthTop + NOTCH_H, body);
+
+        // Mouth area background (slightly darker to show the "inside")
+        render.fill(mouthLeft, mouthTop, x + w, mouthBot, darkenSlightly(darkenSlightly(body)));
+
+        // Border
+        drawOutline(render, x, y, w, h, border);
+        // Mouth border lines
+        render.fill(mouthLeft, mouthTop, x + w, mouthTop + 1, border);      // mouth top edge
+        render.fill(mouthLeft, mouthBot - 1, x + w, mouthBot, border);      // mouth bottom edge
+        render.fill(mouthLeft, mouthTop, mouthLeft + 1, mouthBot, border);  // mouth left edge
+    }
+
+    // ── CAP block: notch top, flat bottom ────────────────────────────────────
+    public static void drawCapBlock(GuiRender render, double x, double y,
+                                     double w, double h, int body, int border) {
+        // Main body
+        render.fill(x, y, x + w, y + h, body);
+
+        // Notch cutout at top
+        double nx = x + NOTCH_INSET;
+        render.fill(nx, y, nx + NOTCH_W, y + NOTCH_H, darkenSlightly(body));
+
+        // No bump at bottom (cap = terminator)
+        // Flat bottom with slightly thicker border to signal "end"
+        render.fill(x, y + h - 2, x + w, y + h, border);
+
+        // Border
+        drawOutline(render, x, y, w, h, border);
+    }
+
+    // ── Shared drawing helpers ────────────────────────────────────────────────
+
+    /** Draws a 1px outline rectangle. */
+    private static void drawOutline(GuiRender render, double x, double y,
+                                     double w, double h, int color) {
+        render.fill(x, y, x + w, y + 1, color);         // top
+        render.fill(x, y + h - 1, x + w, y + h, color); // bottom
+        render.fill(x, y, x + 1, y + h, color);         // left
+        render.fill(x + w - 1, y, x + w, y + h, color); // right
+    }
+
+    /** Draws an approximated rounded cap (semicircle fill). */
+    private static void drawRoundedCap(GuiRender render, double x, double y,
+                                        double r, double h, int color, boolean isLeft) {
+        int steps = Math.max(4, (int) r);
+        for (int i = 0; i < steps; i++) {
+            double t = (i + 0.5) / steps;
+            double angle = Math.PI * t;
+            double capW = Math.sin(angle) * r;
+            double capY = y + t * h;
+            double capH = h / steps;
+            if (isLeft) {
+                render.fill(x + r - capW, capY, x + r, capY + capH, color);
+            } else {
+                render.fill(x, capY, x + capW, capY + capH, color);
+            }
+        }
+    }
+
+    /** Draws the border pixels around a rounded cap. */
+    private static void drawRoundedCapBorder(GuiRender render, double x, double y,
+                                              double r, double h, int color, boolean isLeft) {
+        int steps = Math.max(8, (int) (r * 2));
+        for (int i = 0; i <= steps; i++) {
+            double t = (double) i / steps;
+            double angle = Math.PI * t;
+            double cx = isLeft ? x + r - Math.sin(angle) * r : x + Math.sin(angle) * r;
+            double cy = y + t * h;
+            render.fill(cx - 0.5, cy - 0.5, cx + 0.5, cy + 0.5, color);
+        }
+    }
+
+    /** Darkens a colour slightly for depth effects. */
+    private static int darkenSlightly(int argb) {
+        float factor = 0.7f;
+        int a = (argb >> 24) & 0xFF;
+        int r = (int) (((argb >> 16) & 0xFF) * factor);
+        int g = (int) (((argb >> 8) & 0xFF) * factor);
+        int b = (int) ((argb & 0xFF) * factor);
+        return (a << 24) | (r << 16) | (g << 8) | b;
+    }
+}

--- a/common/src/main/java/net/creeperhost/polylib/client/modulargui/lib/geometry/SnapZoneHelper.java
+++ b/common/src/main/java/net/creeperhost/polylib/client/modulargui/lib/geometry/SnapZoneHelper.java
@@ -1,0 +1,27 @@
+package net.creeperhost.polylib.client.modulargui.lib.geometry;
+
+/**
+ * Geometric helpers for Scratch-style block snapping interactions.
+ */
+public final class SnapZoneHelper {
+    private SnapZoneHelper() {}
+
+    /** Returns the Y coordinate of the snap zone at the bottom of a block. */
+    public static double snapBumpY(double blockY, double blockH) {
+        return blockY + blockH;
+    }
+
+    /** Returns the Y coordinate of the snap zone at the top of a block (notch). */
+    public static double snapNotchY(double blockY) {
+        return blockY;
+    }
+
+    /** Returns true if a point is within snap proximity of a notch/bump. */
+    public static boolean isInSnapZone(double dropX, double dropY,
+                                        double targetX, double targetY,
+                                        double targetW, double snapRadius) {
+        return dropX >= targetX - snapRadius &&
+               dropX <= targetX + targetW + snapRadius &&
+               Math.abs(dropY - targetY) < snapRadius;
+    }
+}

--- a/common/src/main/java/net/creeperhost/polylib/client/modulargui/nodegraph/NodeTypeRegistry.java
+++ b/common/src/main/java/net/creeperhost/polylib/client/modulargui/nodegraph/NodeTypeRegistry.java
@@ -1,0 +1,40 @@
+package net.creeperhost.polylib.client.modulargui.nodegraph;
+
+import net.creeperhost.polylib.client.modulargui.nodegraph.graph.INodeType;
+import net.minecraft.resources.Identifier;
+
+import java.util.*;
+
+/**
+ * Central registry for all {@link INodeType} implementations.
+ *
+ * <p>Call {@link #register(INodeType)} during mod initialisation (before any world loads).
+ * This is a simple static map — no DeferredRegister is needed because node types do not
+ * need world/registry context during registration.</p>
+ */
+public final class NodeTypeRegistry {
+
+    private NodeTypeRegistry() {}
+
+    private static final Map<Identifier, INodeType> REGISTRY = new LinkedHashMap<>();
+
+    public static void register(INodeType type) {
+        Identifier id = type.getTypeId();
+        if (REGISTRY.containsKey(id)) {
+            throw new IllegalStateException("NodeTypeRegistry: duplicate registration for " + id);
+        }
+        REGISTRY.put(id, type);
+    }
+
+    public static Optional<INodeType> get(Identifier id) {
+        return Optional.ofNullable(REGISTRY.get(id));
+    }
+
+    public static Collection<INodeType> getAll() {
+        return Collections.unmodifiableCollection(REGISTRY.values());
+    }
+
+    public static boolean contains(Identifier id) {
+        return REGISTRY.containsKey(id);
+    }
+}

--- a/common/src/main/java/net/creeperhost/polylib/client/modulargui/nodegraph/graph/ConnectionDef.java
+++ b/common/src/main/java/net/creeperhost/polylib/client/modulargui/nodegraph/graph/ConnectionDef.java
@@ -1,0 +1,42 @@
+package net.creeperhost.polylib.client.modulargui.nodegraph.graph;
+
+import net.minecraft.nbt.CompoundTag;
+
+import java.util.UUID;
+
+/**
+ * Immutable description of one directed wire between two node ports.
+ *
+ * <p>A connection is valid iff:
+ * <ul>
+ *   <li>{@code fromNode} exists in the graph and has an OUT port at {@code fromPort}.</li>
+ *   <li>{@code toNode} exists and has an IN port at {@code toPort}.</li>
+ *   <li>The two port data types are compatible per {@link PortDescriptor.PortDataType#compatible}.</li>
+ *   <li>Adding this connection does not create a cycle in the graph.</li>
+ * </ul>
+ */
+public record ConnectionDef(UUID id, UUID fromNode, int fromPort, UUID toNode, int toPort) {
+
+    public CompoundTag toNbt() {
+        CompoundTag tag = new CompoundTag();
+        tag.putString("id",        id.toString());
+        tag.putString("from_node", fromNode.toString());
+        tag.putInt("from_port",    fromPort);
+        tag.putString("to_node",   toNode.toString());
+        tag.putInt("to_port",      toPort);
+        return tag;
+    }
+
+    public static ConnectionDef fromNbt(CompoundTag tag) {
+        try {
+            UUID id       = UUID.fromString(tag.getString("id").orElse(""));
+            UUID fromNode = UUID.fromString(tag.getString("from_node").orElse(""));
+            int  fromPort = tag.getInt("from_port").orElse(0);
+            UUID toNode   = UUID.fromString(tag.getString("to_node").orElse(""));
+            int  toPort   = tag.getInt("to_port").orElse(0);
+            return new ConnectionDef(id, fromNode, fromPort, toNode, toPort);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/common/src/main/java/net/creeperhost/polylib/client/modulargui/nodegraph/graph/INodeType.java
+++ b/common/src/main/java/net/creeperhost/polylib/client/modulargui/nodegraph/graph/INodeType.java
@@ -1,0 +1,58 @@
+package net.creeperhost.polylib.client.modulargui.nodegraph.graph;
+
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.resources.Identifier;
+import net.minecraft.network.chat.Component;
+
+import java.util.List;
+
+/**
+ * Contract that every automation node type must fulfil.
+ *
+ * <p>Implementations are registered via {@link net.creeperhost.polylib.client.modulargui.nodegraph.NodeTypeRegistry}
+ * and must be singletons — one instance per type, shared across all {@link NodeDef} instances
+ * that reference the same {@link #getTypeId()}.</p>
+ *
+ * <p>The GUI side (settings widget construction) is intentionally left out of this
+ * interface so the common module stays free of client dependencies.  Mods may provide
+ * an additional {@code INodeTypeGui} interface on the client side that extends this one
+ * and adds {@code buildSettingsWidget}.</p>
+ */
+public interface INodeType {
+
+    /** Unique identifier for this node type.  Must never change after release. */
+    Identifier getTypeId();
+
+    /** Human-readable name shown in the node header and palette. */
+    Component getDisplayName();
+
+    /**
+     * Returns the port layout for a given node instance.
+     *
+     * <p>The list is stable: a specific index always refers to the same logical port.
+     * If a node's settings change the number of ports, old connections referencing
+     * now-absent port indices are considered broken and should be pruned.</p>
+     *
+     * @param node the node instance whose settings may influence the port layout
+     * @return immutable ordered list of port descriptors
+     */
+    List<PortDescriptor> getPorts(NodeDef node);
+
+    /**
+     * Returns default settings for a newly created node of this type.
+     * The returned tag is copied into the new {@link NodeDef} — callers may mutate it.
+     */
+    default CompoundTag defaultSettings() {
+        return new CompoundTag();
+    }
+
+    /**
+     * Called once per server tick for each node of this type in each active graph.
+     * Implementations read from input ports, perform their logic, and write results.
+     *
+     * @param node the node definition (position, settings, UUID)
+     */
+    default void evaluate(NodeDef node) {
+        // No-op by default.
+    }
+}

--- a/common/src/main/java/net/creeperhost/polylib/client/modulargui/nodegraph/graph/NodeDef.java
+++ b/common/src/main/java/net/creeperhost/polylib/client/modulargui/nodegraph/graph/NodeDef.java
@@ -1,0 +1,99 @@
+package net.creeperhost.polylib.client.modulargui.nodegraph.graph;
+
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.resources.Identifier;
+
+import java.util.UUID;
+
+/**
+ * Mutable description of one node in a {@link NodeGraph}.
+ *
+ * <p>Each node has a permanent {@link #id} (UUID), a {@link #typeId} that maps to
+ * a registered {@link INodeType}, a canvas position ({@link #x}, {@link #y}), and
+ * a type-specific settings blob ({@link #settings}).</p>
+ *
+ * <p>Instances are owned by a {@link NodeGraph}.  Do not share them across graphs.</p>
+ */
+public final class NodeDef {
+
+    private final UUID id;
+    private final Identifier typeId;
+    private int x;
+    private int y;
+    private boolean collapsed;
+    private CompoundTag settings;
+
+    public NodeDef(UUID id, Identifier typeId, int x, int y, boolean collapsed, CompoundTag settings) {
+        this.id       = id;
+        this.typeId   = typeId;
+        this.x        = x;
+        this.y        = y;
+        this.collapsed = collapsed;
+        this.settings = settings != null ? settings : new CompoundTag();
+    }
+
+    public NodeDef(UUID id, Identifier typeId, int x, int y, CompoundTag settings) {
+        this(id, typeId, x, y, false, settings);
+    }
+
+    // ── Accessors ─────────────────────────────────────────────────────────────
+
+    public UUID id()             { return id; }
+    public Identifier typeId()   { return typeId; }
+    public int x()               { return x; }
+    public int y()               { return y; }
+    public boolean isCollapsed() { return collapsed; }
+    public CompoundTag settings(){ return settings; }
+
+    // ── Mutators ──────────────────────────────────────────────────────────────
+
+    public void setPosition(int x, int y) {
+        this.x = x;
+        this.y = y;
+    }
+
+    public void setCollapsed(boolean collapsed) {
+        this.collapsed = collapsed;
+    }
+
+    public void setSettings(CompoundTag settings) {
+        this.settings = settings != null ? settings : new CompoundTag();
+    }
+
+    // ── Serialization ─────────────────────────────────────────────────────────
+
+    public CompoundTag toNbt() {
+        CompoundTag tag = new CompoundTag();
+        tag.putString("id",   id.toString());
+        tag.putString("type", typeId.toString());
+        tag.putInt("x", x);
+        tag.putInt("y", y);
+        if (collapsed) {
+            tag.putBoolean("collapsed", true);
+        }
+        if (!settings.isEmpty()) {
+            tag.put("settings", settings.copy());
+        }
+        return tag;
+    }
+
+    public static NodeDef fromNbt(CompoundTag tag) {
+        try {
+            UUID id       = UUID.fromString(tag.getString("id").orElse(""));
+            Identifier rl = Identifier.parse(tag.getString("type").orElse("polylib:unknown"));
+            int x         = tag.getInt("x").orElse(0);
+            int y         = tag.getInt("y").orElse(0);
+            boolean col   = tag.getBoolean("collapsed").orElse(false);
+            net.minecraft.nbt.Tag settingsTag = tag.get("settings");
+            CompoundTag settings = (settingsTag instanceof CompoundTag ct) ? ct : new CompoundTag();
+            return new NodeDef(id, rl, x, y, col, settings);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "NodeDef{id=" + id + ", type=" + typeId + ", x=" + x + ", y=" + y + "}";
+    }
+}

--- a/common/src/main/java/net/creeperhost/polylib/client/modulargui/nodegraph/graph/NodeGraph.java
+++ b/common/src/main/java/net/creeperhost/polylib/client/modulargui/nodegraph/graph/NodeGraph.java
@@ -1,0 +1,178 @@
+package net.creeperhost.polylib.client.modulargui.nodegraph.graph;
+
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.Tag;
+
+import java.util.*;
+
+/**
+ * Mutable directed acyclic graph of automation nodes and their connections.
+ *
+ * <p>This is the server-authoritative data structure.  Client-side code receives
+ * a copy over the network and re-applies mutations as the user interacts with the
+ * editor.  The server validates each mutation before applying it to the authoritative
+ * graph stored in your block entity.</p>
+ *
+ * <p>Not thread-safe — all mutations must happen on the server tick thread.</p>
+ */
+public final class NodeGraph {
+
+    private final Map<UUID, NodeDef>  nodes       = new LinkedHashMap<>();
+    private final List<ConnectionDef> connections = new ArrayList<>();
+
+    // ── Node operations ───────────────────────────────────────────────────────
+
+    public Map<UUID, NodeDef> nodes() {
+        return Collections.unmodifiableMap(nodes);
+    }
+
+    public List<ConnectionDef> connections() {
+        return Collections.unmodifiableList(connections);
+    }
+
+    public void addNode(NodeDef node) {
+        nodes.put(node.id(), node);
+    }
+
+    public boolean removeNode(UUID id) {
+        if (!nodes.containsKey(id)) return false;
+        nodes.remove(id);
+        connections.removeIf(c -> c.fromNode().equals(id) || c.toNode().equals(id));
+        return true;
+    }
+
+    public boolean moveNode(UUID id, int x, int y) {
+        NodeDef node = nodes.get(id);
+        if (node == null) return false;
+        node.setPosition(x, y);
+        return true;
+    }
+
+    public boolean updateNodeSettings(UUID id, CompoundTag settings) {
+        NodeDef node = nodes.get(id);
+        if (node == null) return false;
+        node.setSettings(settings);
+        return true;
+    }
+
+    // ── Connection operations ─────────────────────────────────────────────────
+
+    public boolean addConnection(ConnectionDef conn) {
+        if (!nodes.containsKey(conn.fromNode())) return false;
+        if (!nodes.containsKey(conn.toNode()))   return false;
+        for (ConnectionDef existing : connections) {
+            if (existing.toNode().equals(conn.toNode()) && existing.toPort() == conn.toPort()) return false;
+        }
+        if (conn.fromNode().equals(conn.toNode())) return false;
+        connections.add(conn);
+        if (hasCycle()) {
+            connections.remove(connections.size() - 1);
+            return false;
+        }
+        return true;
+    }
+
+    public boolean removeConnection(UUID id) {
+        return connections.removeIf(c -> c.id().equals(id));
+    }
+
+    // ── Cycle detection ───────────────────────────────────────────────────────
+
+    public boolean hasCycle() {
+        Set<UUID> visited = new HashSet<>();
+        Set<UUID> inStack = new HashSet<>();
+        for (UUID id : nodes.keySet()) {
+            if (dfsCycle(id, visited, inStack)) return true;
+        }
+        return false;
+    }
+
+    private boolean dfsCycle(UUID node, Set<UUID> visited, Set<UUID> inStack) {
+        if (inStack.contains(node))  return true;
+        if (visited.contains(node))  return false;
+        visited.add(node);
+        inStack.add(node);
+        for (ConnectionDef conn : connections) {
+            if (conn.fromNode().equals(node)) {
+                if (dfsCycle(conn.toNode(), visited, inStack)) return true;
+            }
+        }
+        inStack.remove(node);
+        return false;
+    }
+
+    // ── Topological order ─────────────────────────────────────────────────────
+
+    public List<UUID> topologicalOrder() {
+        Map<UUID, Integer> inDegree = new HashMap<>();
+        nodes.keySet().forEach(id -> inDegree.put(id, 0));
+        for (ConnectionDef conn : connections) {
+            inDegree.merge(conn.toNode(), 1, Integer::sum);
+        }
+        Queue<UUID> queue = new ArrayDeque<>();
+        inDegree.forEach((id, deg) -> { if (deg == 0) queue.add(id); });
+        List<UUID> order = new ArrayList<>();
+        while (!queue.isEmpty()) {
+            UUID cur = queue.poll();
+            order.add(cur);
+            for (ConnectionDef conn : connections) {
+                if (conn.fromNode().equals(cur)) {
+                    int newDeg = inDegree.merge(conn.toNode(), -1, Integer::sum);
+                    if (newDeg == 0) queue.add(conn.toNode());
+                }
+            }
+        }
+        return order;
+    }
+
+    // ── Serialization ─────────────────────────────────────────────────────────
+
+    public CompoundTag toNbt() {
+        CompoundTag root = new CompoundTag();
+        ListTag nodeList = new ListTag();
+        for (NodeDef node : nodes.values()) {
+            nodeList.add(node.toNbt());
+        }
+        root.put("nodes", nodeList);
+        ListTag connList = new ListTag();
+        for (ConnectionDef conn : connections) {
+            connList.add(conn.toNbt());
+        }
+        root.put("connections", connList);
+        return root;
+    }
+
+    public static NodeGraph fromNbt(CompoundTag root) {
+        NodeGraph graph = new NodeGraph();
+        if (root == null) return graph;
+        Tag nodesTag = root.get("nodes");
+        if (nodesTag instanceof ListTag nodeList) {
+            for (Tag t : nodeList) {
+                if (t instanceof CompoundTag ct) {
+                    NodeDef node = NodeDef.fromNbt(ct);
+                    if (node != null) graph.nodes.put(node.id(), node);
+                }
+            }
+        }
+        Tag connsTag = root.get("connections");
+        if (connsTag instanceof ListTag connList) {
+            for (Tag t : connList) {
+                if (t instanceof CompoundTag ct) {
+                    ConnectionDef conn = ConnectionDef.fromNbt(ct);
+                    if (conn != null) graph.connections.add(conn);
+                }
+            }
+        }
+        return graph;
+    }
+
+    public boolean isEmpty() {
+        return nodes.isEmpty();
+    }
+
+    @Override
+    public String toString() {
+        return "NodeGraph{nodes=" + nodes.size() + ", connections=" + connections.size() + "}";
+    }
+}

--- a/common/src/main/java/net/creeperhost/polylib/client/modulargui/nodegraph/graph/PortDescriptor.java
+++ b/common/src/main/java/net/creeperhost/polylib/client/modulargui/nodegraph/graph/PortDescriptor.java
@@ -1,0 +1,69 @@
+package net.creeperhost.polylib.client.modulargui.nodegraph.graph;
+
+/**
+ * Describes a single input or output port on a node.
+ *
+ * <p>Ports are identified by their {@link #index()} within the list returned by
+ * {@link INodeType#getPorts(NodeDef)}.  Indices are stable — a node type must
+ * never change what port lives at a given index, or all saved connections become
+ * invalid.</p>
+ */
+public record PortDescriptor(int index, String label, PortDirection direction, PortDataType dataType) {
+
+    // ── Direction ─────────────────────────────────────────────────────────────
+
+    public enum PortDirection {
+        /** This port receives data / items / signals from an upstream node. */
+        IN,
+        /** This port sends data / items / signals to a downstream node. */
+        OUT
+    }
+
+    // ── Data types ────────────────────────────────────────────────────────────
+
+    public enum PortDataType {
+        /** Transfers {@link net.minecraft.world.item.ItemStack} streams. */
+        ITEMS,
+        /** Transfers fluid amounts (mB units). */
+        FLUID,
+        /** Boolean signal — high (true) or low (false). */
+        SIGNAL,
+        /** Accepts any data type — used by pass-through nodes like Relay. */
+        ANY;
+
+        /**
+         * Returns true if a connection from {@code outType} → {@code inType} is type-compatible.
+         * Any side being {@link #ANY} makes the connection valid.
+         */
+        public static boolean compatible(PortDataType outType, PortDataType inType) {
+            if (outType == ANY || inType == ANY) return true;
+            return outType == inType;
+        }
+    }
+
+    // ── Factory helpers ───────────────────────────────────────────────────────
+
+    public static PortDescriptor itemIn(int index, String label) {
+        return new PortDescriptor(index, label, PortDirection.IN, PortDataType.ITEMS);
+    }
+
+    public static PortDescriptor itemOut(int index, String label) {
+        return new PortDescriptor(index, label, PortDirection.OUT, PortDataType.ITEMS);
+    }
+
+    public static PortDescriptor signalIn(int index, String label) {
+        return new PortDescriptor(index, label, PortDirection.IN, PortDataType.SIGNAL);
+    }
+
+    public static PortDescriptor signalOut(int index, String label) {
+        return new PortDescriptor(index, label, PortDirection.OUT, PortDataType.SIGNAL);
+    }
+
+    public static PortDescriptor anyIn(int index, String label) {
+        return new PortDescriptor(index, label, PortDirection.IN, PortDataType.ANY);
+    }
+
+    public static PortDescriptor anyOut(int index, String label) {
+        return new PortDescriptor(index, label, PortDirection.OUT, PortDataType.ANY);
+    }
+}

--- a/common/src/main/resources/assets/polylib/shaders/bezier_wire.fsh
+++ b/common/src/main/resources/assets/polylib/shaders/bezier_wire.fsh
@@ -1,0 +1,51 @@
+#version 330
+
+layout(std140) uniform BezierWire {
+    vec2 p0;
+    vec2 p1;
+    vec2 p2;
+    vec2 p3;
+    vec2 size;
+};
+
+layout(std140) uniform Projection {
+    mat4 ProjMat;
+};
+
+in vec4 vertexColor;
+
+out vec4 fragColor;
+
+float length2(in vec2 v) { return dot(v, v); }
+
+float sdSegmentSq(in vec2 p, in vec2 a, in vec2 b) {
+    vec2 pa = p - a, ba = b - a;
+    float h = clamp(dot(pa, ba) / dot(ba, ba), 0.0, 1.0);
+    return length2(pa - ba * h);
+}
+
+// Unsigned squared distance from pos to cubic bezier p0..p3.
+// Evaluated by walking 120 sub-segments on GPU.
+float udBezierSq(vec2 pos) {
+    const int kNum = 120;
+    float best = 1e10;
+    vec2 a = p0;
+    for (int i = 1; i < kNum; i++) {
+        float t = float(i) / float(kNum - 1);
+        float s = 1.0 - t;
+        vec2 b = p0*(s*s*s) + p1*(3.0*s*s*t) + p2*(3.0*s*t*t) + p3*(t*t*t);
+        float d = sdSegmentSq(pos, a, b);
+        if (d < best) best = d;
+        a = b;
+    }
+    return best;
+}
+
+void main() {
+    // PiP y=0 is at the top; gl_FragCoord.y=0 is at the bottom — flip y.
+    vec2 fragPos = vec2(gl_FragCoord.x, size.y - gl_FragCoord.y) / size;
+    float distSq = udBezierSq(fragPos);
+    float alpha = 1.0 - smoothstep(0.0, 0.00002, distSq);
+    if (alpha < 0.0002) discard;
+    fragColor = vec4(vertexColor.rgb, vertexColor.a * alpha);
+}

--- a/common/src/main/resources/assets/polylib/shaders/bezier_wire.vsh
+++ b/common/src/main/resources/assets/polylib/shaders/bezier_wire.vsh
@@ -1,0 +1,22 @@
+#version 330
+
+layout(std140) uniform DynamicTransforms {
+    mat4 ModelViewMat;
+    vec4 ColorModulator;
+    vec3 ModelOffset;
+    mat4 TextureMat;
+};
+
+layout(std140) uniform Projection {
+    mat4 ProjMat;
+};
+
+in vec3 Position;
+in vec4 Color;
+
+out vec4 vertexColor;
+
+void main() {
+    gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
+    vertexColor = Color;
+}

--- a/neoforge/src/main/java/net/creeperhost/polylib/PolyLibClientNeoForge.java
+++ b/neoforge/src/main/java/net/creeperhost/polylib/PolyLibClientNeoForge.java
@@ -1,10 +1,18 @@
 package net.creeperhost.polylib;
 
+import net.creeperhost.polylib.client.modulargui.nodegraph.render.BezierWirePiPRenderer;
+import net.creeperhost.polylib.client.modulargui.nodegraph.render.BezierWireRenderState;
+import net.creeperhost.polylib.client.modulargui.nodegraph.render.BezierWireUniform;
+import net.creeperhost.polylib.client.modulargui.nodegraph.render.NodeCanvasRenderPipelines;
 import net.creeperhost.polylib.client.modulargui.sprite.PolyTextures;
 import net.minecraft.client.resources.model.sprite.AtlasManager;
 import net.neoforged.bus.api.IEventBus;
+import net.neoforged.neoforge.client.event.RegisterPictureInPictureRenderersEvent;
+import net.neoforged.neoforge.client.event.RegisterRenderPipelinesEvent;
 import net.neoforged.neoforge.client.event.RegisterTextureAtlasesEvent;
 import net.neoforged.neoforge.client.event.TextureAtlasStitchedEvent;
+import net.neoforged.neoforge.client.event.RenderFrameEvent;
+import net.neoforged.neoforge.common.NeoForge;
 
 public class PolyLibClientNeoForge
 {
@@ -12,6 +20,10 @@ public class PolyLibClientNeoForge
     {
         eventBus.addListener(PolyLibClientNeoForge::atlasStitched);
         eventBus.addListener(PolyLibClientNeoForge::registerTextureAtlas);
+        // Node canvas GPU bezier wires
+        eventBus.addListener(PolyLibClientNeoForge::registerNodeCanvasPipelines);
+        eventBus.addListener(PolyLibClientNeoForge::registerNodeCanvasPiPs);
+        NeoForge.EVENT_BUS.addListener(PolyLibClientNeoForge::onRenderFrameEnd);
     }
 
     private static void registerTextureAtlas(RegisterTextureAtlasesEvent event) {
@@ -24,4 +36,17 @@ public class PolyLibClientNeoForge
             PolyTextures.setAtlas(event.getAtlas());
         }
     }
+
+    private static void registerNodeCanvasPipelines(RegisterRenderPipelinesEvent event) {
+        event.registerPipeline(NodeCanvasRenderPipelines.BEZIER_WIRE);
+    }
+
+    private static void registerNodeCanvasPiPs(RegisterPictureInPictureRenderersEvent event) {
+        event.register(BezierWireRenderState.class, BezierWirePiPRenderer::new);
+    }
+
+    private static void onRenderFrameEnd(RenderFrameEvent.Post event) {
+        BezierWireUniform.STORAGE.get().endFrame();
+    }
 }
+

--- a/neoforge/src/main/java/net/creeperhost/polylib/client/modulargui/nodegraph/render/BezierWirePiPRenderer.java
+++ b/neoforge/src/main/java/net/creeperhost/polylib/client/modulargui/nodegraph/render/BezierWirePiPRenderer.java
@@ -1,0 +1,116 @@
+package net.creeperhost.polylib.client.modulargui.nodegraph.render;
+
+import com.mojang.blaze3d.systems.GpuDevice;
+import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.blaze3d.vertex.*;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.navigation.ScreenRectangle;
+import net.minecraft.client.renderer.MultiBufferSource;
+import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
+
+import java.util.Objects;
+import java.util.OptionalInt;
+
+/**
+ * NeoForge PiP renderer that draws a single GPU bezier wire per submitted state.
+ *
+ * <p>Register once via {@code RegisterPictureInPictureRenderersEvent}:
+ * <pre>
+ *     event.register(BezierWireRenderState.class, BezierWirePiPRenderer::new);
+ * </pre>
+ *
+ * <p>Call {@code BezierWireUniform.STORAGE.get().endFrame()} in
+ * {@code RenderFrameEvent.Post} to reclaim UBO ring-buffer slots each frame.
+ *
+ * <p>Textures are cached: if the render state is unchanged from the last frame
+ * the GPU texture is reused without re-rendering.
+ */
+public class BezierWirePiPRenderer
+        extends net.minecraft.client.gui.render.pip.PictureInPictureRenderer<BezierWireRenderState> {
+
+    private BezierWireRenderState lastState;
+
+    public BezierWirePiPRenderer(MultiBufferSource.BufferSource bufferSource) {
+        super(bufferSource);
+    }
+
+    @Override
+    public @NotNull Class<BezierWireRenderState> getRenderStateClass() {
+        return BezierWireRenderState.class;
+    }
+
+    @Override
+    protected boolean textureIsReadyToBlit(BezierWireRenderState state) {
+        return this.lastState != null && this.lastState.equals(state);
+    }
+
+    @Override
+    protected void renderToTexture(BezierWireRenderState state, @NonNull PoseStack poseStack) {
+        ScreenRectangle bounds = state.bounds();
+        float scale = (float) Minecraft.getInstance().getWindow().getGuiScale();
+        float sw = bounds.width()  * scale;
+        float sh = bounds.height() * scale;
+        ScreenRectangle scaledBounds = new ScreenRectangle(0, 0, (int) sw, (int) sh);
+        BezierWireUniform uniform = new BezierWireUniform(state.controlPoints(), scaledBounds);
+        GpuDevice device = RenderSystem.getDevice();
+        var target = Minecraft.getInstance().getMainRenderTarget();
+        try (var byteBuffer = new ByteBufferBuilder(256)) {
+            var buffer = new BufferBuilder(byteBuffer, VertexFormat.Mode.QUADS,
+                    DefaultVertexFormat.POSITION_COLOR);
+            buffer.addVertex(0f,  0f,  0f).setColor(state.colour());
+            buffer.addVertex(0f,  sh,  0f).setColor(state.colour());
+            buffer.addVertex(sw,  sh,  0f).setColor(state.colour());
+            buffer.addVertex(sw,  0f,  0f).setColor(state.colour());
+            MeshData mesh = buffer.buildOrThrow();
+            var gpuBufs = buildGpuBuffers(mesh);
+            var encoder = device.createCommandEncoder();
+            var dynamicUniforms = RenderSystem.getDynamicUniforms().writeTransform(
+                    RenderSystem.getModelViewMatrix(),
+                    new org.joml.Vector4f(1f, 1f, 1f, 1f),
+                    new org.joml.Vector3f(),
+                    new org.joml.Matrix4f()
+            );
+            var bezierSlice = BezierWireUniform.STORAGE.get().writeUniform(uniform);
+            try (mesh; var pass = encoder.createRenderPass(
+                    () -> "PolyLib BezierWire PiP",
+                    Objects.requireNonNullElse(RenderSystem.outputColorTextureOverride, target.getColorTextureView()),
+                    OptionalInt.empty()
+            )) {
+                pass.setPipeline(NodeCanvasRenderPipelines.BEZIER_WIRE);
+                RenderSystem.bindDefaultUniforms(pass);
+                pass.setUniform("DynamicTransforms", dynamicUniforms);
+                pass.setUniform(BezierWireUniform.NAME, bezierSlice);
+                pass.setVertexBuffer(0, gpuBufs.vertex());
+                pass.setIndexBuffer(gpuBufs.index(), gpuBufs.type());
+                pass.drawIndexed(0, 0, mesh.drawState().indexCount(), 1);
+            }
+        }
+        this.lastState = state;
+    }
+
+    @Override
+    protected @NotNull String getTextureLabel() {
+        return "polylib_bezier_wire";
+    }
+
+    private record GpuBufs(
+            com.mojang.blaze3d.buffers.GpuBuffer vertex,
+            com.mojang.blaze3d.buffers.GpuBuffer index,
+            VertexFormat.IndexType type) {}
+
+    private static GpuBufs buildGpuBuffers(MeshData mesh) {
+        var pipeline = NodeCanvasRenderPipelines.BEZIER_WIRE;
+        com.mojang.blaze3d.buffers.GpuBuffer vertex =
+                pipeline.getVertexFormat().uploadImmediateVertexBuffer(mesh.vertexBuffer());
+        if (mesh.indexBuffer() == null) {
+            var seq = RenderSystem.getSequentialBuffer(mesh.drawState().mode());
+            return new GpuBufs(vertex, seq.getBuffer(mesh.drawState().indexCount()), seq.type());
+        }
+        return new GpuBufs(
+                vertex,
+                pipeline.getVertexFormat().uploadImmediateIndexBuffer(mesh.indexBuffer()),
+                mesh.drawState().indexType()
+        );
+    }
+}

--- a/neoforge/src/main/java/net/creeperhost/polylib/client/modulargui/nodegraph/render/BezierWireRenderState.java
+++ b/neoforge/src/main/java/net/creeperhost/polylib/client/modulargui/nodegraph/render/BezierWireRenderState.java
@@ -1,0 +1,70 @@
+package net.creeperhost.polylib.client.modulargui.nodegraph.render;
+
+import net.creeperhost.polylib.client.modulargui.elements.GuiNodeCanvas;
+import net.minecraft.client.gui.navigation.ScreenRectangle;
+import net.minecraft.client.renderer.state.gui.pip.PictureInPictureRenderState;
+import org.joml.Matrix3x2f;
+import org.joml.Vector2f;
+import org.joml.Vector2fc;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Immutable render-state for one GPU bezier wire.
+ *
+ * <p>Submit via {@code GuiGraphicsExtractor.submitPictureInPictureRenderState(state)},
+ * accessible through PolyLib's {@code GuiRender.graphics()}.
+ *
+ * <p>Use as the {@link GuiNodeCanvas.BezierStateFactory}:
+ * <pre>
+ *     canvas.setBezierStateFactory(BezierWireRenderState::fromScreen);
+ * </pre>
+ */
+public record BezierWireRenderState(
+        Matrix3x2f pose,
+        Vector2fc[] controlPoints,   // normalised [0,1] within bounds
+        int colour,
+        ScreenRectangle bounds
+) implements PictureInPictureRenderState {
+
+    /**
+     * Build from four screen-space control points and the current GUI pose.
+     *
+     * @param pose       2D GUI pose (copy of {@code GuiRender.pose()})
+     * @param screenPts  4 control points in GUI pixel space
+     * @param colour     ARGB wire colour
+     */
+    public static BezierWireRenderState fromScreen(Matrix3x2f pose,
+                                                    Vector2fc[] screenPts,
+                                                    int colour) {
+        float minX = Float.MAX_VALUE, minY = Float.MAX_VALUE;
+        float maxX = -Float.MAX_VALUE, maxY = -Float.MAX_VALUE;
+        for (Vector2fc p : screenPts) {
+            float tx = pose.m00() * p.x() + pose.m10() * p.y() + pose.m20();
+            float ty = pose.m01() * p.x() + pose.m11() * p.y() + pose.m21();
+            if (tx < minX) minX = tx;
+            if (ty < minY) minY = ty;
+            if (tx > maxX) maxX = tx;
+            if (ty > maxY) maxY = ty;
+        }
+        int bx = (int) Math.floor(minX);
+        int by = (int) Math.floor(minY);
+        int bw = Math.max(1, (int) Math.ceil(maxX) - bx);
+        int bh = Math.max(1, (int) Math.ceil(maxY) - by);
+        ScreenRectangle bounds = new ScreenRectangle(bx, by, bw, bh);
+
+        Vector2fc[] rel = new Vector2fc[4];
+        for (int i = 0; i < 4; i++) {
+            float tx = pose.m00() * screenPts[i].x() + pose.m10() * screenPts[i].y() + pose.m20();
+            float ty = pose.m01() * screenPts[i].x() + pose.m11() * screenPts[i].y() + pose.m21();
+            rel[i] = new Vector2f((tx - bx) / (float) bw, (ty - by) / (float) bh);
+        }
+        return new BezierWireRenderState(pose, rel, colour, bounds);
+    }
+
+    @Override public int x0()    { return bounds.left();   }
+    @Override public int x1()    { return bounds.right();  }
+    @Override public int y0()    { return bounds.top();    }
+    @Override public int y1()    { return bounds.bottom(); }
+    @Override public float scale() { return 1f; }
+    @Override public @Nullable ScreenRectangle scissorArea() { return null; }
+}

--- a/neoforge/src/main/java/net/creeperhost/polylib/client/modulargui/nodegraph/render/BezierWireUniform.java
+++ b/neoforge/src/main/java/net/creeperhost/polylib/client/modulargui/nodegraph/render/BezierWireUniform.java
@@ -1,0 +1,53 @@
+package net.creeperhost.polylib.client.modulargui.nodegraph.render;
+
+import com.google.common.base.Suppliers;
+import com.mojang.blaze3d.buffers.Std140Builder;
+import com.mojang.blaze3d.buffers.Std140SizeCalculator;
+import net.minecraft.client.gui.navigation.ScreenRectangle;
+import net.minecraft.client.renderer.DynamicUniformStorage;
+import org.joml.Vector2fc;
+
+import java.nio.ByteBuffer;
+import java.util.function.Supplier;
+
+/**
+ * GPU uniform block for the PolyLib bezier wire shader.
+ *
+ * <p>std140 layout:
+ * <pre>
+ *   vec2 p0   – normalised control point 0 (start)
+ *   vec2 p1   – normalised control point 1 (out-tangent)
+ *   vec2 p2   – normalised control point 2 (in-tangent)
+ *   vec2 p3   – normalised control point 3 (end)
+ *   vec2 size – PiP texture pixel dimensions
+ * </pre>
+ *
+ * <p>Call {@code STORAGE.get().endFrame()} in a {@code RenderFrameEvent.Post}
+ * handler to release UBO slots at the end of each frame.
+ */
+public record BezierWireUniform(Vector2fc[] controlPoints, ScreenRectangle area)
+        implements DynamicUniformStorage.DynamicUniform {
+
+    public static final String NAME = "BezierWire";
+
+    public static final Supplier<DynamicUniformStorage<BezierWireUniform>> STORAGE =
+            Suppliers.memoize(() -> new DynamicUniformStorage<>(
+                    NAME + " UBO",
+                    new Std140SizeCalculator()
+                            .putVec2().putVec2().putVec2().putVec2() // 4 control points
+                            .putVec2()                               // size
+                            .get(),
+                    64
+            ));
+
+    @Override
+    public void write(ByteBuffer buffer) {
+        Std140Builder.intoBuffer(buffer)
+                .putVec2(controlPoints[0])
+                .putVec2(controlPoints[1])
+                .putVec2(controlPoints[2])
+                .putVec2(controlPoints[3])
+                .putVec2(area.width(), area.height())
+                .get();
+    }
+}

--- a/neoforge/src/main/java/net/creeperhost/polylib/client/modulargui/nodegraph/render/NodeCanvasBezierRenderer.java
+++ b/neoforge/src/main/java/net/creeperhost/polylib/client/modulargui/nodegraph/render/NodeCanvasBezierRenderer.java
@@ -1,0 +1,29 @@
+package net.creeperhost.polylib.client.modulargui.nodegraph.render;
+
+import net.creeperhost.polylib.client.modulargui.elements.GuiNodeCanvas;
+import org.joml.Matrix3x2f;
+
+/**
+ * Utility that provides the GPU bezier {@link GuiNodeCanvas.BezierRenderer} implementation
+ * for NeoForge.
+ *
+ * <p>Call {@link #renderer()} at canvas construction time to wire GPU bezier rendering:
+ * <pre>
+ *     GuiNodeCanvas canvas = new GuiNodeCanvas(parent);
+ *     canvas.setBezierRenderer(NodeCanvasBezierRenderer.renderer());
+ * </pre>
+ */
+public final class NodeCanvasBezierRenderer {
+
+    private NodeCanvasBezierRenderer() {}
+
+    /**
+     * Returns a {@link GuiNodeCanvas.BezierRenderer} that submits a GPU distance-field
+     * bezier wire via the NeoForge PiP system.
+     */
+    public static GuiNodeCanvas.BezierRenderer renderer() {
+        return (render, pose, screenPts, colour) ->
+                render.graphics().submitPictureInPictureRenderState(
+                        BezierWireRenderState.fromScreen(new Matrix3x2f(pose), screenPts, colour));
+    }
+}

--- a/neoforge/src/main/java/net/creeperhost/polylib/client/modulargui/nodegraph/render/NodeCanvasRenderPipelines.java
+++ b/neoforge/src/main/java/net/creeperhost/polylib/client/modulargui/nodegraph/render/NodeCanvasRenderPipelines.java
@@ -1,0 +1,37 @@
+package net.creeperhost.polylib.client.modulargui.nodegraph.render;
+
+import com.mojang.blaze3d.pipeline.BlendFunction;
+import com.mojang.blaze3d.pipeline.ColorTargetState;
+import com.mojang.blaze3d.pipeline.RenderPipeline;
+import com.mojang.blaze3d.shaders.UniformType;
+import com.mojang.blaze3d.vertex.DefaultVertexFormat;
+import com.mojang.blaze3d.vertex.VertexFormat;
+import net.minecraft.resources.Identifier;
+
+/**
+ * NeoForge render pipelines for the PolyLib node canvas.
+ *
+ * <p>Register from a {@code RegisterRenderPipelinesEvent} listener:
+ * <pre>
+ *     event.registerPipeline(NodeCanvasRenderPipelines.BEZIER_WIRE);
+ * </pre>
+ *
+ * <p>Shaders are at {@code assets/polylib/shaders/bezier_wire.vsh/.fsh}
+ * in the common module resources.
+ */
+public final class NodeCanvasRenderPipelines {
+
+    public static final RenderPipeline BEZIER_WIRE = RenderPipeline.builder()
+            .withUniform("DynamicTransforms",    UniformType.UNIFORM_BUFFER)
+            .withUniform("Projection",           UniformType.UNIFORM_BUFFER)
+            .withUniform(BezierWireUniform.NAME, UniformType.UNIFORM_BUFFER)
+            .withLocation(Identifier.fromNamespaceAndPath("polylib", "pipeline/bezier_wire"))
+            .withVertexShader(Identifier.fromNamespaceAndPath("polylib", "bezier_wire"))
+            .withFragmentShader(Identifier.fromNamespaceAndPath("polylib", "bezier_wire"))
+            .withCull(false)
+            .withVertexFormat(DefaultVertexFormat.POSITION_COLOR, VertexFormat.Mode.QUADS)
+            .withColorTargetState(new ColorTargetState(BlendFunction.TRANSLUCENT))
+            .build();
+
+    private NodeCanvasRenderPipelines() {}
+}


### PR DESCRIPTION
## Summary

Adds a full node-graph/visual-scripting UI system built on `GuiPannableCanvas`, with GPU-accelerated bezier wire rendering on NeoForge.

### Changes
- `GuiNodeCanvas` — canvas element that hosts and renders a node graph
- `GuiWindow` — draggable floating window element
- `NodeTypeRegistry` — registry for node types
- Node graph data model: `NodeGraph`, `NodeDef`, `INodeType`, `ConnectionDef`, `PortDescriptor`
- NeoForge render pipeline: `NodeCanvasRenderPipelines`, `NodeCanvasBezierRenderer`, `BezierWirePiPRenderer`, `BezierWireRenderState`, `BezierWireUniform`
- GLSL shaders: `bezier_wire.fsh` / `bezier_wire.vsh`
- `GuiButton.vanillaVerticalTab()` — new tab button factory
- `GuiContextMenu` and `GuiText` improvements

### Notes
- Depends on `feat/pannable-canvas`
- Bezier wire GPU rendering is NeoForge-only (no Fabric render pipeline equivalent yet)