### PR TITLE
feat(chat): add modular chat channel/router system with floating chat window

### DIFF
--- a/common/src/main/java/net/creeperhost/polylib/chat/ChatChannel.java
+++ b/common/src/main/java/net/creeperhost/polylib/chat/ChatChannel.java
@@ -1,0 +1,95 @@
+package net.creeperhost.polylib.chat;
+
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.Identifier;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Consumer;
+
+/**
+ * Represents an isolated stream of messages and members.
+ */
+public class ChatChannel {
+    private final Identifier channelId;
+    private final Component name;
+    private final boolean canReply;
+
+    private final List<ChatMember> members = new ArrayList<>();
+    private final List<RichChatMessage> messages = new ArrayList<>();
+    
+    private final List<Consumer<RichChatMessage>> messageListeners = new ArrayList<>();
+
+    public ChatChannel(Identifier channelId, Component name, boolean canReply) {
+        this.channelId = channelId;
+        this.name = name;
+        this.canReply = canReply;
+    }
+
+    public Identifier getChannelId() {
+        return channelId;
+    }
+
+    public Component getName() {
+        return name;
+    }
+
+    public boolean canReply() {
+        return canReply;
+    }
+
+    public List<ChatMember> getMembers() {
+        return Collections.unmodifiableList(members);
+    }
+
+    public void addMember(ChatMember member) {
+        members.removeIf(m -> m.memberId().equals(member.memberId()));
+        members.add(member);
+    }
+
+    public void removeMember(UUID memberId) {
+        members.removeIf(m -> m.memberId().equals(memberId));
+    }
+
+    public Optional<ChatMember> getMember(UUID memberId) {
+        return members.stream().filter(m -> m.memberId().equals(memberId)).findFirst();
+    }
+
+    public List<RichChatMessage> getMessages() {
+        return Collections.unmodifiableList(messages);
+    }
+
+    public void addMessage(RichChatMessage message) {
+        this.messages.add(message);
+        // keep buffer size reasonable
+        if (this.messages.size() > 1000) {
+            this.messages.remove(0);
+        }
+        for (Consumer<RichChatMessage> listener : messageListeners) {
+            listener.accept(message);
+        }
+    }
+
+    public void addMessageListener(Consumer<RichChatMessage> listener) {
+        this.messageListeners.add(listener);
+    }
+
+    public void removeMessageListener(Consumer<RichChatMessage> listener) {
+        this.messageListeners.remove(listener);
+    }
+
+    private Consumer<String> messageSubmitHandler;
+
+    public void setSubmitHandler(Consumer<String> handler) {
+        this.messageSubmitHandler = handler;
+    }
+
+    public void submitMessage(String message) {
+        if (messageSubmitHandler != null) {
+            messageSubmitHandler.accept(message);
+        }
+    }
+}

--- a/common/src/main/java/net/creeperhost/polylib/chat/ChatMember.java
+++ b/common/src/main/java/net/creeperhost/polylib/chat/ChatMember.java
@@ -1,0 +1,22 @@
+package net.creeperhost.polylib.chat;
+
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.Identifier;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.UUID;
+
+/**
+ * Represents a member/participant in a ChatChannel sidebar.
+ * Can represent a Player, a Shell, or an Automation Controller.
+ */
+public record ChatMember(
+        UUID memberId,
+        Component displayName,
+        @Nullable Identifier icon,
+        boolean isOnline
+) {
+    public ChatMember withOnlineStatus(boolean online) {
+        return new ChatMember(memberId, displayName, icon, online);
+    }
+}

--- a/common/src/main/java/net/creeperhost/polylib/chat/ChatRouter.java
+++ b/common/src/main/java/net/creeperhost/polylib/chat/ChatRouter.java
@@ -1,0 +1,50 @@
+package net.creeperhost.polylib.chat;
+
+import net.minecraft.resources.Identifier;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Manages active chat channels and routes messages.
+ */
+public class ChatRouter {
+    private static final ChatRouter INSTANCE = new ChatRouter();
+    
+    private final Map<Identifier, ChatChannel> channels = new ConcurrentHashMap<>();
+
+    private ChatRouter() {}
+
+    public static ChatRouter getInstance() {
+        return INSTANCE;
+    }
+
+    public void registerChannel(ChatChannel channel) {
+        channels.put(channel.getChannelId(), channel);
+    }
+
+    public void unregisterChannel(Identifier channelId) {
+        channels.remove(channelId);
+    }
+
+    public ChatChannel getChannel(Identifier channelId) {
+        return channels.get(channelId);
+    }
+
+    public Collection<ChatChannel> getActiveChannels() {
+        return Collections.unmodifiableCollection(channels.values());
+    }
+
+    /**
+     * Routes a message to a specific channel.
+     */
+    public boolean routeMessage(Identifier channelId, RichChatMessage message) {
+        ChatChannel channel = channels.get(channelId);
+        if (channel != null) {
+            channel.addMessage(message);
+            return true;
+        }
+        return false;
+    }
+}

--- a/common/src/main/java/net/creeperhost/polylib/chat/RichChatMessage.java
+++ b/common/src/main/java/net/creeperhost/polylib/chat/RichChatMessage.java
@@ -1,0 +1,32 @@
+package net.creeperhost.polylib.chat;
+
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.Identifier;
+import org.jetbrains.annotations.Nullable;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Represents a single message in the PolyLib Modular Chat Framework.
+ */
+public record RichChatMessage(
+        UUID messageId,
+        Component content,
+        Instant timestamp,
+        Component senderName,
+        @Nullable Identifier senderIcon,
+        @Nullable UUID senderId
+) {
+    public static RichChatMessage create(Component content, Component senderName) {
+        return new RichChatMessage(UUID.randomUUID(), content, Instant.now(), senderName, null, null);
+    }
+
+    public static RichChatMessage create(Component content, Component senderName, Identifier senderIcon) {
+        return new RichChatMessage(UUID.randomUUID(), content, Instant.now(), senderName, senderIcon, null);
+    }
+
+    public static RichChatMessage create(Component content, Component senderName, Identifier senderIcon, UUID senderId) {
+        return new RichChatMessage(UUID.randomUUID(), content, Instant.now(), senderName, senderIcon, senderId);
+    }
+}

--- a/common/src/main/java/net/creeperhost/polylib/chat/client/ChatWindowManager.java
+++ b/common/src/main/java/net/creeperhost/polylib/chat/client/ChatWindowManager.java
@@ -1,0 +1,54 @@
+package net.creeperhost.polylib.chat.client;
+
+import net.creeperhost.polylib.chat.layout.ChatWindowLayout;
+import net.creeperhost.polylib.client.modulargui.elements.GuiWindow;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Manages multiple GuiWindows, handles Z-indexing, focus, snapping, and tiling.
+ */
+public class ChatWindowManager {
+    private static final int SNAP_DISTANCE = 10;
+    
+    private final List<GuiWindow> managedWindows = new ArrayList<>();
+
+    public ChatWindowManager() {
+    }
+
+    public void addWindow(GuiWindow window) {
+        managedWindows.add(window);
+        
+        // Add hooking for move completion to do snapping
+        window.setOnMovedCallback(() -> handleWindowMoved(window));
+    }
+
+    public void removeWindow(GuiWindow window) {
+        managedWindows.remove(window);
+    }
+
+    public void bringToFront(GuiWindow window) {
+        if (managedWindows.remove(window)) {
+            managedWindows.add(window);
+        }
+    }
+
+    private void handleWindowMoved(GuiWindow movedWindow) {
+        // Simple edge-snapping logic
+        for (GuiWindow other : managedWindows) {
+            if (other == movedWindow) continue;
+
+            // Snap left edge to right edge
+            if (Math.abs(movedWindow.xMin - other.xMax) < SNAP_DISTANCE) {
+                // If y overlap exists
+                if (movedWindow.yMax > other.yMin && movedWindow.yMin < other.yMax) {
+                    movedWindow.xMin = other.xMax;
+                    movedWindow.xMax = movedWindow.xMin + movedWindow.getMinSize().width(); // or preserve width
+                }
+            }
+            
+            // Further snapping logic can be expanded here
+        }
+    }
+}

--- a/common/src/main/java/net/creeperhost/polylib/chat/client/FloatingChatWindow.java
+++ b/common/src/main/java/net/creeperhost/polylib/chat/client/FloatingChatWindow.java
@@ -1,0 +1,149 @@
+package net.creeperhost.polylib.chat.client;
+
+import net.creeperhost.polylib.chat.ChatChannel;
+import net.creeperhost.polylib.chat.ChatMember;
+import net.creeperhost.polylib.chat.RichChatMessage;
+import net.creeperhost.polylib.client.modulargui.elements.GuiButton;
+import net.creeperhost.polylib.client.modulargui.elements.GuiRectangle;
+import net.creeperhost.polylib.client.modulargui.elements.GuiScrolling;
+import net.creeperhost.polylib.client.modulargui.elements.GuiText;
+import net.creeperhost.polylib.client.modulargui.elements.GuiTextField;
+import net.creeperhost.polylib.client.modulargui.elements.GuiTexture;
+import net.creeperhost.polylib.client.modulargui.elements.GuiWindow;
+import net.creeperhost.polylib.client.modulargui.lib.geometry.Constraint;
+import net.creeperhost.polylib.client.modulargui.sprite.Material;
+import net.creeperhost.polylib.client.modulargui.lib.geometry.GeoParam;
+import net.creeperhost.polylib.client.modulargui.lib.geometry.GuiParent;
+import net.creeperhost.polylib.client.modulargui.elements.GuiElement;
+
+/**
+ * The actual chat UI that renders a ChatChannel.
+ */
+public class FloatingChatWindow extends GuiWindow {
+
+    private final ChatChannel channel;
+    
+    private final GuiRectangle sidebar;
+    private final GuiScrolling messageArea;
+    private final GuiTextField inputField;
+
+    public FloatingChatWindow(GuiParent<?> parent, ChatChannel channel) {
+        super(parent);
+        this.channel = channel;
+        
+        setTitle(channel.getName());
+
+        // Setup Sidebar
+        this.sidebar = new GuiRectangle(getBackground());
+        this.sidebar.constrain(GeoParam.RIGHT, Constraint.match(getBackground().get(GeoParam.RIGHT)))
+                    .constrain(GeoParam.TOP, Constraint.match(getHeaderBar().get(GeoParam.BOTTOM)))
+                    .constrain(GeoParam.BOTTOM, Constraint.match(getBackground().get(GeoParam.BOTTOM)))
+                    .constrain(GeoParam.WIDTH, Constraint.literal(50))
+                    .fill(0x55000000);
+
+        // Setup Message Area
+        this.messageArea = new GuiScrolling(getBackground());
+        this.messageArea.constrain(GeoParam.LEFT, Constraint.match(getBackground().get(GeoParam.LEFT)))
+                        .constrain(GeoParam.RIGHT, Constraint.match(sidebar.get(GeoParam.LEFT)))
+                        .constrain(GeoParam.TOP, Constraint.match(getHeaderBar().get(GeoParam.BOTTOM)))
+                        .constrain(GeoParam.BOTTOM, Constraint.relative(getBackground().get(GeoParam.BOTTOM), channel.canReply() ? -20 : 0));
+
+        // Setup Input Field (only if channel supports replies)
+        if (channel.canReply()) {
+            this.inputField = new GuiTextField(getBackground());
+            this.inputField.constrain(GeoParam.LEFT, Constraint.match(getBackground().get(GeoParam.LEFT)))
+                           .constrain(GeoParam.RIGHT, Constraint.match(getBackground().get(GeoParam.RIGHT)))
+                           .constrain(GeoParam.BOTTOM, Constraint.match(getBackground().get(GeoParam.BOTTOM)))
+                           .constrain(GeoParam.HEIGHT, Constraint.literal(20));
+                           
+            this.inputField.setEnterPressed(() -> {
+                String text = this.inputField.getValue();
+                if (!text.isEmpty()) {
+                    this.channel.submitMessage(text);
+                    this.inputField.setValue("");
+                }
+            });
+        } else {
+            this.inputField = null;
+        }
+
+        // Hook up listeners
+        this.channel.addMessageListener(this::onNewMessage);
+        
+        // Initial render
+        refreshMembers();
+        refreshMessages();
+    }
+
+    private void onNewMessage(RichChatMessage message) {
+        refreshMessages();
+    }
+
+    private void refreshMembers() {
+        new java.util.ArrayList<>(sidebar.getChildren()).forEach(sidebar::removeChild);
+        
+        GuiText headerText = new GuiText(sidebar);
+        headerText.setText(net.minecraft.network.chat.Component.literal("Members"));
+        headerText.constrain(GeoParam.LEFT, Constraint.relative(sidebar.get(GeoParam.LEFT), 2))
+                .constrain(GeoParam.TOP, Constraint.relative(sidebar.get(GeoParam.TOP), 2));
+        
+        GuiElement<?> lastElement = headerText;
+        
+        for (ChatMember member : channel.getMembers()) {
+            GuiText nameText = new GuiText(sidebar);
+            nameText.setText(member.displayName());
+            nameText.constrain(GeoParam.LEFT, Constraint.relative(sidebar.get(GeoParam.LEFT), 2))
+                    .constrain(GeoParam.TOP, Constraint.relative(lastElement.get(GeoParam.BOTTOM), 2))
+                    .constrain(GeoParam.RIGHT, Constraint.relative(sidebar.get(GeoParam.RIGHT), -2))
+                    .setWrap(true).setAlignment(net.creeperhost.polylib.client.modulargui.lib.geometry.Align.MIN).autoHeight();
+            
+            lastElement = nameText;
+        }
+    }
+
+    private void refreshMessages() {
+        new java.util.ArrayList<>(messageArea.getContentElement().getChildren()).forEach(messageArea.getContentElement()::removeChild);
+        
+        // Prevent horizontal scroll by constraining width
+        messageArea.getContentElement().constrain(GeoParam.WIDTH, Constraint.match(messageArea.get(GeoParam.WIDTH)));
+        
+        GuiElement<?> lastElement = null;
+        for (RichChatMessage msg : channel.getMessages()) {
+            GuiElement<?> container = new GuiElement<>(messageArea.getContentElement());
+            container.constrain(GeoParam.LEFT, Constraint.match(messageArea.getContentElement().get(GeoParam.LEFT)));
+            container.constrain(GeoParam.RIGHT, Constraint.match(messageArea.getContentElement().get(GeoParam.RIGHT)));
+            
+            if (lastElement == null) {
+                container.constrain(GeoParam.TOP, Constraint.match(messageArea.getContentElement().get(GeoParam.TOP)));
+            } else {
+                container.constrain(GeoParam.TOP, Constraint.match(lastElement.get(GeoParam.BOTTOM)));
+            }
+
+            double currentX = 2;
+            
+            if (msg.senderIcon() != null) {
+                GuiTexture icon = new GuiTexture(container, Material.fromRawTexture(msg.senderIcon()));
+                icon.constrain(GeoParam.LEFT, Constraint.relative(container.get(GeoParam.LEFT), currentX))
+                    .constrain(GeoParam.TOP, Constraint.relative(container.get(GeoParam.TOP), 2))
+                    .constrain(GeoParam.WIDTH, Constraint.literal(8))
+                    .constrain(GeoParam.HEIGHT, Constraint.literal(8));
+                currentX += 10;
+            }
+
+            GuiText msgText = new GuiText(container);
+            msgText.setText(net.minecraft.network.chat.Component.literal("<")
+                .append(msg.senderName())
+                .append("> ")
+                .append(msg.content()));
+                
+            msgText.constrain(GeoParam.LEFT, Constraint.relative(container.get(GeoParam.LEFT), currentX))
+                   .constrain(GeoParam.TOP, Constraint.match(container.get(GeoParam.TOP)))
+                   .constrain(GeoParam.RIGHT, Constraint.relative(container.get(GeoParam.RIGHT), -2))
+                   .setWrap(true).setAlignment(net.creeperhost.polylib.client.modulargui.lib.geometry.Align.MIN).autoHeight();
+            
+            container.constrain(GeoParam.HEIGHT, Constraint.relative(msgText.get(GeoParam.HEIGHT), 2));
+            
+            lastElement = container;
+        }
+    }
+}

--- a/common/src/main/java/net/creeperhost/polylib/chat/layout/ChatLayoutManager.java
+++ b/common/src/main/java/net/creeperhost/polylib/chat/layout/ChatLayoutManager.java
@@ -1,0 +1,84 @@
+package net.creeperhost.polylib.chat.layout;
+
+import com.google.gson.*;
+import com.google.gson.reflect.TypeToken;
+import net.creeperhost.polylib.Constants;
+import net.minecraft.client.Minecraft;
+import net.minecraft.resources.Identifier;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Manages saving and loading of ChatWindowLayouts to the local client disk.
+ */
+public class ChatLayoutManager {
+    private static final Gson GSON = new GsonBuilder()
+            .setPrettyPrinting()
+            .registerTypeAdapter(Identifier.class, (JsonSerializer<Identifier>) (src, typeOfSrc, context) -> new JsonPrimitive(src.toString()))
+            .registerTypeAdapter(Identifier.class, (JsonDeserializer<Identifier>) (json, typeOfT, context) -> Identifier.parse(json.getAsString()))
+            .create();
+            
+    private final List<ChatWindowLayout> activeLayouts = new ArrayList<>();
+    private File layoutFile;
+
+    public ChatLayoutManager() {
+    }
+
+    public void init() {
+        if (Minecraft.getInstance() != null) {
+            File polyDir = new File(Minecraft.getInstance().gameDirectory, "config/polylib");
+            polyDir.mkdirs();
+            this.layoutFile = new File(polyDir, "chat_layouts.json");
+            load();
+        }
+    }
+
+    public List<ChatWindowLayout> getActiveLayouts() {
+        return activeLayouts;
+    }
+
+    public ChatWindowLayout getOrCreateLayout(String layoutId) {
+        for (ChatWindowLayout layout : activeLayouts) {
+            if (layout.getLayoutId().equals(layoutId)) {
+                return layout;
+            }
+        }
+        ChatWindowLayout newLayout = new ChatWindowLayout(layoutId, 10, 10, 200, 150);
+        activeLayouts.add(newLayout);
+        save();
+        return newLayout;
+    }
+
+    public void removeLayout(String layoutId) {
+        activeLayouts.removeIf(l -> l.getLayoutId().equals(layoutId));
+        save();
+    }
+
+    public void save() {
+        if (layoutFile == null) return;
+        try (FileWriter writer = new FileWriter(layoutFile)) {
+            GSON.toJson(activeLayouts, writer);
+        } catch (Exception e) {
+            Constants.LOG.error("Failed to save chat layouts", e);
+        }
+    }
+
+    public void load() {
+        if (layoutFile == null || !layoutFile.exists()) return;
+        try (FileReader reader = new FileReader(layoutFile)) {
+            Type listType = new TypeToken<ArrayList<ChatWindowLayout>>(){}.getType();
+            List<ChatWindowLayout> loaded = GSON.fromJson(reader, listType);
+            if (loaded != null) {
+                activeLayouts.clear();
+                activeLayouts.addAll(loaded);
+            }
+        } catch (Exception e) {
+            Constants.LOG.error("Failed to load chat layouts", e);
+        }
+    }
+}

--- a/common/src/main/java/net/creeperhost/polylib/chat/layout/ChatWindowLayout.java
+++ b/common/src/main/java/net/creeperhost/polylib/chat/layout/ChatWindowLayout.java
@@ -1,0 +1,118 @@
+package net.creeperhost.polylib.chat.layout;
+
+import net.minecraft.resources.Identifier;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Represents the on-screen layout properties of a floating chat window.
+ * This state is persisted to disk.
+ */
+public class ChatWindowLayout {
+    private final String layoutId; // Could be a UUID or a custom string identifier for the window grouping
+    
+    // Position and dimensions (normalized or absolute screen coordinates)
+    private int x;
+    private int y;
+    private int width;
+    private int height;
+    
+    private boolean isPinned;
+    private boolean isHidden;
+    
+    // Which channels are docked in this window (for tabs)
+    private final List<Identifier> tabbedChannels = new ArrayList<>();
+    // Which tab is currently active/visible
+    private Identifier activeTab;
+
+    public ChatWindowLayout(String layoutId, int x, int y, int width, int height) {
+        this.layoutId = layoutId;
+        this.x = x;
+        this.y = y;
+        this.width = width;
+        this.height = height;
+    }
+
+    public String getLayoutId() {
+        return layoutId;
+    }
+
+    public int getX() {
+        return x;
+    }
+
+    public void setX(int x) {
+        this.x = x;
+    }
+
+    public int getY() {
+        return y;
+    }
+
+    public void setY(int y) {
+        this.y = y;
+    }
+
+    public int getWidth() {
+        return width;
+    }
+
+    public void setWidth(int width) {
+        this.width = width;
+    }
+
+    public int getHeight() {
+        return height;
+    }
+
+    public void setHeight(int height) {
+        this.height = height;
+    }
+
+    public boolean isPinned() {
+        return isPinned;
+    }
+
+    public void setPinned(boolean pinned) {
+        isPinned = pinned;
+    }
+
+    public boolean isHidden() {
+        return isHidden;
+    }
+
+    public void setHidden(boolean hidden) {
+        isHidden = hidden;
+    }
+
+    public List<Identifier> getTabbedChannels() {
+        return tabbedChannels;
+    }
+
+    public void addTab(Identifier channelId) {
+        if (!tabbedChannels.contains(channelId)) {
+            tabbedChannels.add(channelId);
+        }
+        if (activeTab == null) {
+            activeTab = channelId;
+        }
+    }
+
+    public void removeTab(Identifier channelId) {
+        tabbedChannels.remove(channelId);
+        if (activeTab != null && activeTab.equals(channelId)) {
+            activeTab = tabbedChannels.isEmpty() ? null : tabbedChannels.get(0);
+        }
+    }
+
+    public Identifier getActiveTab() {
+        return activeTab;
+    }
+
+    public void setActiveTab(Identifier activeTab) {
+        if (tabbedChannels.contains(activeTab)) {
+            this.activeTab = activeTab;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a modular chat channel/routing system with a floating draggable chat window built on `ModularGui`.

### Changes
- `ChatChannel` — named channel with member list and message history
- `ChatMember` — participant representation
- `ChatRouter` — singleton routing messages to registered channels
- `RichChatMessage` — message wrapper with sender metadata
- `ChatWindowManager` + `FloatingChatWindow` — draggable modular chat UI
- `ChatLayoutManager` + `ChatWindowLayout` — layout persistence

### Notes
- Client-side window system; server-side routing is separate from vanilla chat