### PR TITLE
feat(containers): add ContainerSyncProtocol for typed container data sync

### DIFF
--- a/common/src/main/java/net/creeperhost/polylib/containers/ModularGuiContainerMenu.java
+++ b/common/src/main/java/net/creeperhost/polylib/containers/ModularGuiContainerMenu.java
@@ -26,6 +26,8 @@ import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
+import net.creeperhost.polylib.containers.network.PolyContainerSyncProtocol;
+
 /**
  * The base abstract ContainerMenu for all modular gui containers.
  * <p>
@@ -33,6 +35,8 @@ import java.util.function.Consumer;
  */
 public abstract class ModularGuiContainerMenu extends AbstractContainerMenu {
     private static final Logger LOGGER = LogManager.getLogger();
+
+    public final PolyContainerSyncProtocol syncProtocol = new PolyContainerSyncProtocol(this);
 
     public final Inventory inventory;
     public final List<SlotGroup> slotGroups = new ArrayList<>();
@@ -144,7 +148,9 @@ public abstract class ModularGuiContainerMenu extends AbstractContainerMenu {
      * Requires a client to server packet handler to be installed via {@link #setClientToServerPacketHandler(Consumer)}
      */
     public void handlePacketFromClient(Player player, int packetId, RegistryFriendlyByteBuf packet) {
-
+        if (packetId == 254) {
+            syncProtocol.handleClientPacket(player, packet);
+        }
     }
 
     public static void handlePacketFromServer(Player player, RegistryFriendlyByteBuf packet) {
@@ -162,6 +168,10 @@ public abstract class ModularGuiContainerMenu extends AbstractContainerMenu {
      * Don't forget to call super if you plan on using the {@link DataSync} system.
      */
     public void handlePacketFromServer(Player player, int packetId, RegistryFriendlyByteBuf packet) {
+        if (packetId == 254) {
+            syncProtocol.handleServerPacket(player, packet);
+            return;
+        }
         if (packetId == 255) {
             int index = packet.readByte() & 0xFF;
             if (dataSyncs.size() > index) {

--- a/common/src/main/java/net/creeperhost/polylib/containers/network/ContainerSyncProtocol.java
+++ b/common/src/main/java/net/creeperhost/polylib/containers/network/ContainerSyncProtocol.java
@@ -1,0 +1,38 @@
+package net.creeperhost.polylib.containers.network;
+
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.resources.Identifier;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.player.Player;
+
+import java.util.function.BiConsumer;
+
+/**
+ * Protocol adapter for synchronizing data between server and client containers.
+ * Replaces the need for raw byte buffer manipulation and manual packet ID assignments.
+ */
+public interface ContainerSyncProtocol {
+
+    /**
+     * Sends a typed payload to the client-side container.
+     */
+    <T> void sendToClient(ServerPlayer player, int containerId, SyncPayloadType<T> type, T payload);
+
+    /**
+     * Sends a typed payload to the server-side container.
+     */
+    <T> void sendToServer(int containerId, SyncPayloadType<T> type, T payload);
+
+    /**
+     * Registers a handler for a specific payload type from the server.
+     */
+    <T> void registerClientHandler(SyncPayloadType<T> type, BiConsumer<Player, T> handler);
+
+    /**
+     * Registers a handler for a specific payload type from the client.
+     */
+    <T> void registerServerHandler(SyncPayloadType<T> type, BiConsumer<Player, T> handler);
+
+    record SyncPayloadType<T>(Identifier id, StreamCodec<RegistryFriendlyByteBuf, T> codec) {}
+}

--- a/common/src/main/java/net/creeperhost/polylib/containers/network/PolyContainerSyncProtocol.java
+++ b/common/src/main/java/net/creeperhost/polylib/containers/network/PolyContainerSyncProtocol.java
@@ -1,0 +1,77 @@
+package net.creeperhost.polylib.containers.network;
+
+import net.creeperhost.polylib.containers.ModularGuiContainerMenu;
+import net.creeperhost.polylib.network.PolyLibNetwork;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.player.Player;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+public class PolyContainerSyncProtocol implements ContainerSyncProtocol {
+
+    private final ModularGuiContainerMenu container;
+    private final Map<String, BiConsumer<Player, ?>> clientHandlers = new HashMap<>();
+    private final Map<String, BiConsumer<Player, ?>> serverHandlers = new HashMap<>();
+    private final Map<String, SyncPayloadType<?>> types = new HashMap<>();
+
+    public PolyContainerSyncProtocol(ModularGuiContainerMenu container) {
+        this.container = container;
+    }
+
+    @Override
+    public <T> void sendToClient(ServerPlayer player, int containerId, SyncPayloadType<T> type, T payload) {
+        PolyLibNetwork.sendContainerPacketToClient(player, buf -> {
+            buf.writeByte(containerId);
+            buf.writeByte(254); // Special ID for protocol routing
+            buf.writeUtf(type.id().toString());
+            type.codec().encode(buf, payload);
+        });
+    }
+
+    @Override
+    public <T> void sendToServer(int containerId, SyncPayloadType<T> type, T payload) {
+        PolyLibNetwork.sendContainerPacketToServer(container.inventory.player.registryAccess(), buf -> {
+            buf.writeByte(containerId);
+            buf.writeByte(254);
+            buf.writeUtf(type.id().toString());
+            type.codec().encode(buf, payload);
+        });
+    }
+
+    @Override
+    public <T> void registerClientHandler(SyncPayloadType<T> type, BiConsumer<Player, T> handler) {
+        clientHandlers.put(type.id().toString(), handler);
+        types.put(type.id().toString(), type);
+    }
+
+    @Override
+    public <T> void registerServerHandler(SyncPayloadType<T> type, BiConsumer<Player, T> handler) {
+        serverHandlers.put(type.id().toString(), handler);
+        types.put(type.id().toString(), type);
+    }
+
+    @SuppressWarnings("unchecked")
+    public void handleClientPacket(Player player, RegistryFriendlyByteBuf buf) {
+        String id = buf.readUtf();
+        SyncPayloadType<?> type = types.get(id);
+        BiConsumer<Player, Object> handler = (BiConsumer<Player, Object>) clientHandlers.get(id);
+        if (type != null && handler != null) {
+            Object payload = type.codec().decode(buf);
+            handler.accept(player, payload);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public void handleServerPacket(Player player, RegistryFriendlyByteBuf buf) {
+        String id = buf.readUtf();
+        SyncPayloadType<?> type = types.get(id);
+        BiConsumer<Player, Object> handler = (BiConsumer<Player, Object>) serverHandlers.get(id);
+        if (type != null && handler != null) {
+            Object payload = type.codec().decode(buf);
+            handler.accept(player, payload);
+        }
+    }
+}

--- a/testmod-common/src/main/java/net/creeperhost/testmod/blocks/inventorytestblock/BlockEntityInventoryTest.java
+++ b/testmod-common/src/main/java/net/creeperhost/testmod/blocks/inventorytestblock/BlockEntityInventoryTest.java
@@ -88,7 +88,12 @@ public class BlockEntityInventoryTest extends PolyBlockEntity implements PolyInv
     public @Nullable AbstractContainerMenu createMenu(int i, Inventory inventory, Player player)
     {
         lastVisitorUUID.set(player.getUUID());
-        return new ContainerInventoryTest(i, inventory, this);
+        ContainerInventoryTest menu = new ContainerInventoryTest(i, inventory, this);
+        if (player instanceof ServerPlayer serverPlayer) {
+            String hello = "energy=" + (int) energyContainer.getEnergyStored() + "/" + (int) energyContainer.getMaxEnergyStored();
+            menu.syncProtocol.sendToClient(serverPlayer, i, ContainerInventoryTest.SERVER_HELLO, hello);
+        }
+        return menu;
     }
 
     @Override

--- a/testmod-common/src/main/java/net/creeperhost/testmod/blocks/inventorytestblock/ContainerInventoryTest.java
+++ b/testmod-common/src/main/java/net/creeperhost/testmod/blocks/inventorytestblock/ContainerInventoryTest.java
@@ -4,22 +4,46 @@ import net.creeperhost.polylib.client.modulargui.lib.container.DataSync;
 import net.creeperhost.polylib.client.modulargui.lib.container.SlotGroup;
 import net.creeperhost.polylib.containers.DataManagerContainer;
 import net.creeperhost.polylib.containers.ModularGuiContainerMenu;
+import net.creeperhost.polylib.containers.network.ContainerSyncProtocol;
 import net.creeperhost.polylib.containers.slots.PolySlot;
 import net.creeperhost.polylib.data.DataManagerBlock;
 import net.creeperhost.polylib.data.serializable.ByteData;
 import net.creeperhost.polylib.data.serializable.IntData;
+import net.creeperhost.testmod.TestModCommon;
 import net.creeperhost.testmod.init.TestContainers;
 import net.minecraft.client.Minecraft;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.codec.ByteBufCodecs;
+import net.minecraft.resources.Identifier;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.MenuType;
 import net.minecraft.world.level.block.entity.BlockEntity;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class ContainerInventoryTest extends ModularGuiContainerMenu implements DataManagerContainer
 {
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    /**
+     * Tests server→client typed sync: server sends an energy snapshot string on open;
+     * client logs receipt and bounces it back via CLIENT_ECHO.
+     */
+    public static final ContainerSyncProtocol.SyncPayloadType<String> SERVER_HELLO =
+            new ContainerSyncProtocol.SyncPayloadType<>(
+                    Identifier.fromNamespaceAndPath(TestModCommon.MOD_ID, "container_sync_test/server_hello"),
+                    ByteBufCodecs.STRING_UTF8.cast());
+
+    /**
+     * Tests client→server typed sync: client echoes the server hello string back.
+     */
+    public static final ContainerSyncProtocol.SyncPayloadType<String> CLIENT_ECHO =
+            new ContainerSyncProtocol.SyncPayloadType<>(
+                    Identifier.fromNamespaceAndPath(TestModCommon.MOD_ID, "container_sync_test/client_echo"),
+                    ByteBufCodecs.STRING_UTF8.cast());
     public final BlockEntityInventoryTest blockEntity;
     public final SlotGroup main = createSlotGroup(0, 1, 3); //zone id is 0, Quick move to zone 1, then 3
     public final SlotGroup hotBar = createSlotGroup(0, 1, 3);
@@ -46,6 +70,14 @@ public class ContainerInventoryTest extends ModularGuiContainerMenu implements D
         progressSync = new DataSync<>(this, new ByteData(), () -> (byte) blockEntity.progress);
         energy = new DataSync<>(this, new IntData(), () -> (int) blockEntity.energyContainer.getEnergyStored());
         maxEnergy = new DataSync<>(this, new IntData(), () -> (int) blockEntity.energyContainer.getMaxEnergyStored());
+
+        // ContainerSyncProtocol test: client receives SERVER_HELLO and bounces it back as CLIENT_ECHO
+        syncProtocol.registerClientHandler(SERVER_HELLO, (player, msg) -> {
+            LOGGER.info("[ContainerSyncTest] Client received SERVER_HELLO: '{}'", msg);
+            syncProtocol.sendToServer(containerId, CLIENT_ECHO, "echo: " + msg);
+        });
+        syncProtocol.registerServerHandler(CLIENT_ECHO, (player, msg) ->
+                LOGGER.info("[ContainerSyncTest] Server received CLIENT_ECHO from {}: '{}'", player.getName().getString(), msg));
 
         main.addPlayerMain(inventory);
         hotBar.addPlayerBar(inventory);


### PR DESCRIPTION
Adds a typed container data sync protocol on top of the existing `PolyLibNetwork` packet infrastructure.

## Changes

- **`ContainerSyncProtocol`** — new interface defining typed payload registration and bidirectional sync between server and client containers, using `StreamCodec`-based serialization
- **`PolyContainerSyncProtocol`** — implementation wired to the existing `PolyLibNetwork` via packet ID `254` routing in `ModularGuiContainerMenu`
- **`ModularGuiContainerMenu`** — routes incoming packet ID `254` to the registered `ContainerSyncProtocol` handler

Builds clean on both NeoForge and Fabric. NeoForge and Fabric testmod clients verified launching.