### PR TITLE
fix(containers): correct ContainerSyncProtocol dispatch direction and send timing

### DIFF
--- a/common/src/main/java/net/creeperhost/polylib/containers/ModularGuiContainerMenu.java
+++ b/common/src/main/java/net/creeperhost/polylib/containers/ModularGuiContainerMenu.java
@@ -149,7 +149,7 @@ public abstract class ModularGuiContainerMenu extends AbstractContainerMenu {
      */
     public void handlePacketFromClient(Player player, int packetId, RegistryFriendlyByteBuf packet) {
         if (packetId == 254) {
-            syncProtocol.handleClientPacket(player, packet);
+            syncProtocol.handleServerPacket(player, packet);
         }
     }
 
@@ -169,7 +169,7 @@ public abstract class ModularGuiContainerMenu extends AbstractContainerMenu {
      */
     public void handlePacketFromServer(Player player, int packetId, RegistryFriendlyByteBuf packet) {
         if (packetId == 254) {
-            syncProtocol.handleServerPacket(player, packet);
+            syncProtocol.handleClientPacket(player, packet);
             return;
         }
         if (packetId == 255) {

--- a/testmod-common/src/main/java/net/creeperhost/testmod/blocks/inventorytestblock/BlockEntityInventoryTest.java
+++ b/testmod-common/src/main/java/net/creeperhost/testmod/blocks/inventorytestblock/BlockEntityInventoryTest.java
@@ -88,12 +88,7 @@ public class BlockEntityInventoryTest extends PolyBlockEntity implements PolyInv
     public @Nullable AbstractContainerMenu createMenu(int i, Inventory inventory, Player player)
     {
         lastVisitorUUID.set(player.getUUID());
-        ContainerInventoryTest menu = new ContainerInventoryTest(i, inventory, this);
-        if (player instanceof ServerPlayer serverPlayer) {
-            String hello = "energy=" + (int) energyContainer.getEnergyStored() + "/" + (int) energyContainer.getMaxEnergyStored();
-            menu.syncProtocol.sendToClient(serverPlayer, i, ContainerInventoryTest.SERVER_HELLO, hello);
-        }
-        return menu;
+        return new ContainerInventoryTest(i, inventory, this);
     }
 
     @Override

--- a/testmod-common/src/main/java/net/creeperhost/testmod/blocks/inventorytestblock/ContainerInventoryTest.java
+++ b/testmod-common/src/main/java/net/creeperhost/testmod/blocks/inventorytestblock/ContainerInventoryTest.java
@@ -15,6 +15,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.resources.Identifier;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.MenuType;
@@ -45,6 +46,7 @@ public class ContainerInventoryTest extends ModularGuiContainerMenu implements D
                     Identifier.fromNamespaceAndPath(TestModCommon.MOD_ID, "container_sync_test/client_echo"),
                     ByteBufCodecs.STRING_UTF8.cast());
     public final BlockEntityInventoryTest blockEntity;
+    private boolean initialSyncSent = false;
     public final SlotGroup main = createSlotGroup(0, 1, 3); //zone id is 0, Quick move to zone 1, then 3
     public final SlotGroup hotBar = createSlotGroup(0, 1, 3);
     public final SlotGroup armor = createSlotGroup(1, 3, 0); //zone id is 1, Quick move to zone 3, then 0
@@ -87,6 +89,17 @@ public class ContainerInventoryTest extends ModularGuiContainerMenu implements D
 
         machineInputs.addSlots(1, 0, index -> new PolySlot(blockEntity.simpleItemInventory, index));
         machineOutputs.addAllSlots(blockEntity.getOutputContainer(), (container, integer) -> new PolySlot(container, integer).output());
+    }
+
+    @Override
+    public void broadcastChanges() {
+        super.broadcastChanges();
+        if (!initialSyncSent && inventory.player instanceof ServerPlayer serverPlayer) {
+            initialSyncSent = true;
+            String hello = "energy=" + (int) blockEntity.energyContainer.getEnergyStored() + "/" + (int) blockEntity.energyContainer.getMaxEnergyStored();
+            LOGGER.info("[ContainerSyncTest] Server sending SERVER_HELLO: '{}' containerId={}", hello, containerId);
+            syncProtocol.sendToClient(serverPlayer, containerId, SERVER_HELLO, hello);
+        }
     }
 
     @Override


### PR DESCRIPTION
Fixes two bugs introduced in #133 that caused `ContainerSyncProtocol` to silently drop all typed sync messages.

## Bug 1: Dispatch direction swapped in `ModularGuiContainerMenu`

`handlePacketFromClient` (server receiving from client) was calling `syncProtocol.handleClientPacket` — which looks in `clientHandlers`. It should call `handleServerPacket` (looks in `serverHandlers`).

`handlePacketFromServer` (client receiving from server) was calling `syncProtocol.handleServerPacket` — which looks in `serverHandlers`. It should call `handleClientPacket` (looks in `clientHandlers`).

Both directions were swapped, so no registered handlers were ever found.

## Bug 2: `broadcastFullState()` fires before client has opened the container

The server was sending `SERVER_HELLO` in `broadcastFullState()`, but this is called before `ClientboundOpenScreenPacket` arrives on the client. The custom channel packet would arrive while `player.containerMenu` was still the old container, failing the `containerId` check silently.

Fixed by moving the send to `broadcastChanges()` with a one-shot `initialSyncSent` flag, which runs each tick after the client has the container open.

## Verification

Full round-trip confirmed in NeoForge testmod logs:
```
[Server thread/INFO] [ContainerSyncTest] Server sending SERVER_HELLO: 'energy=0/1000000' containerId=1
[Render thread/INFO] [ContainerSyncTest] Client received SERVER_HELLO: 'energy=0/1000000'
[Server thread/INFO] [ContainerSyncTest] Server received CLIENT_ECHO from Dev: 'echo: energy=0/1000000'
```