### PR TITLE
testmod(inventory): expose output inventory on DOWN face for hopper-out testing

### DIFF
--- a/testmod-common/src/main/java/net/creeperhost/testmod/blocks/inventorytestblock/BlockEntityInventoryTest.java
+++ b/testmod-common/src/main/java/net/creeperhost/testmod/blocks/inventorytestblock/BlockEntityInventoryTest.java
@@ -93,6 +93,7 @@ public class BlockEntityInventoryTest extends PolyBlockEntity implements PolyInv
 
     @Override
     public Container getContainer(@org.jetbrains.annotations.Nullable Direction side) {
+        if (side == Direction.DOWN) return outputInv;
         return this.simpleItemInventory;
     }
 


### PR DESCRIPTION
Fixes the testmod inventory block so hoppers can pull from the output slot.

**Changes**

BlockEntityInventoryTest.getContainer(side): returns outputInv when side == Direction.DOWN, so a hopper placed below the block pulls from the output inventory instead of the input inventory.

**Verified in NeoForge testmod:** hopper feeds items into the input slot from the side; block processes them and places a diamond in the output slot; hopper below pulls the diamond out correctly.