### PR TITLE
feat(serverdata): add OfflinePlayerData accessor for reading offline player saves

### DIFF
--- a/common/src/main/java/net/creeperhost/polylib/platform/services/IPlayerDataHelper.java
+++ b/common/src/main/java/net/creeperhost/polylib/platform/services/IPlayerDataHelper.java
@@ -4,8 +4,10 @@ import net.creeperhost.polylib.player.serverdata.PlayerServerDataStore;
 import net.creeperhost.polylib.player.serverdata.PlayerServerDataType;
 import net.creeperhost.polylib.player.settings.PlayerClientSettingsStore;
 import net.creeperhost.polylib.player.settings.PlayerClientSettingsType;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.level.ServerPlayer;
 
+import java.util.Optional;
 import java.util.UUID;
 
 /**
@@ -56,4 +58,21 @@ public interface IPlayerDataHelper
      */
     <T> void loadServerDataForType(UUID playerUUID, ServerPlayer player,
                                     PlayerServerDataStore store, PlayerServerDataType<T> type);
+
+    /**
+     * Read a single server-data type from a raw player NBT CompoundTag (for offline player access).
+     * The {@code playerNbt} is the top-level tag loaded from {@code <world>/playerdata/<uuid>.dat}.
+     * Platform impls read from their own storage key inside that tag
+     * (e.g. {@code ForgeData} on NeoForge, {@code fabric:attachments} on Fabric).
+     *
+     * @return the decoded value, or empty if no value is stored for this type
+     */
+    <T> Optional<T> readOfflineServerData(CompoundTag playerNbt, PlayerServerDataType<T> type);
+
+    /**
+     * Write a single server-data type into a raw player NBT CompoundTag (for offline player access).
+     * The {@code playerNbt} is the top-level tag that will be written back to
+     * {@code <world>/playerdata/<uuid>.dat}.
+     */
+    <T> void writeOfflineServerData(CompoundTag playerNbt, PlayerServerDataType<T> type, T value);
 }

--- a/common/src/main/java/net/creeperhost/polylib/player/serverdata/offline/OfflinePlayerData.java
+++ b/common/src/main/java/net/creeperhost/polylib/player/serverdata/offline/OfflinePlayerData.java
@@ -1,0 +1,36 @@
+package net.creeperhost.polylib.player.serverdata.offline;
+
+import net.creeperhost.polylib.player.serverdata.PlayerServerDataType;
+
+/**
+ * Mutable view of a single player's PolyLib server data, valid for either an
+ * online or offline player.  Obtained via
+ * {@link OfflinePlayerDataAccessor#modify(net.minecraft.server.MinecraftServer, java.util.UUID, java.util.function.Consumer)}.
+ *
+ * <p>For online players every {@link #get}/{@link #set} call goes directly to
+ * {@link net.creeperhost.polylib.player.serverdata.PlayerServerDataManager}.
+ * For offline players the view is backed by the loaded {@code ForgeData}
+ * {@link net.minecraft.nbt.CompoundTag}; changes are written back to
+ * {@code <world>/playerdata/<uuid>.dat} when the {@code modify} call returns.
+ */
+public interface OfflinePlayerData {
+
+    /**
+     * Whether the underlying player is currently online.
+     * If {@code true}, changes take effect immediately in the live store.
+     */
+    boolean isOnline();
+
+    /**
+     * Returns the current value for the given type, or the type's default if
+     * no value has been saved.
+     */
+    <T> T get(PlayerServerDataType<T> type);
+
+    /**
+     * Writes a new value for the given type.
+     * For offline players the change is persisted when the enclosing
+     * {@link OfflinePlayerDataAccessor#modify} call returns.
+     */
+    <T> void set(PlayerServerDataType<T> type, T value);
+}

--- a/common/src/main/java/net/creeperhost/polylib/player/serverdata/offline/OfflinePlayerDataAccessor.java
+++ b/common/src/main/java/net/creeperhost/polylib/player/serverdata/offline/OfflinePlayerDataAccessor.java
@@ -1,12 +1,11 @@
 package net.creeperhost.polylib.player.serverdata.offline;
 
+import net.creeperhost.polylib.platform.Services;
 import net.creeperhost.polylib.player.serverdata.PlayerServerDataManager;
 import net.creeperhost.polylib.player.serverdata.PlayerServerDataType;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.NbtAccounter;
 import net.minecraft.nbt.NbtIo;
-import net.minecraft.nbt.NbtOps;
-import net.minecraft.nbt.Tag;
 import net.minecraft.world.level.storage.LevelResource;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerPlayer;
@@ -30,9 +29,9 @@ import java.util.function.Consumer;
  *
  * <h2>Offline players</h2>
  * Data is read from / written to the player's {@code .dat} file at
- * {@code <world>/playerdata/<uuid>.dat}.  On NeoForge, PolyLib persists
- * server-data values inside the player's {@code ForgeData} compound under keys
- * of the form {@code polylib_sdata.<typeId>}.
+ * {@code <world>/playerdata/<uuid>.dat}.  The exact NBT structure used is
+ * platform-specific: NeoForge stores data inside the {@code ForgeData} compound;
+ * Fabric uses the {@code fabric:attachments} compound.
  *
  * <h2>Thread safety</h2>
  * Must be called from the server tick thread.  No locking is performed because
@@ -59,12 +58,6 @@ public final class OfflinePlayerDataAccessor {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(OfflinePlayerDataAccessor.class);
 
-    /** Key inside the player .dat CompoundTag where NeoForge stores getPersistentData(). */
-    private static final String FORGE_DATA_KEY = "ForgeData";
-
-    /** Key prefix PolyLib uses for server-data types inside ForgeData. */
-    private static final String SDATA_PREFIX = "polylib_sdata.";
-
     private OfflinePlayerDataAccessor() {}
 
     // ── Public API ────────────────────────────────────────────────────────────
@@ -81,8 +74,8 @@ public final class OfflinePlayerDataAccessor {
         ServerPlayer online = server.getPlayerList().getPlayer(uuid);
         if (online != null) return PlayerServerDataManager.get(online, type);
 
-        return readForgeData(server, uuid)
-                .map(fd -> readTyped(fd, type).orElse(type.defaultFactory().get()))
+        return readPlayerNbt(server, uuid)
+                .map(nbt -> Services.PLAYER_DATA.readOfflineServerData(nbt, type).orElse(type.defaultFactory().get()))
                 .orElse(type.defaultFactory().get());
     }
 
@@ -99,7 +92,7 @@ public final class OfflinePlayerDataAccessor {
             PlayerServerDataManager.set(online, type, value);
             return true;
         }
-        return modifyFile(server, uuid, fd -> writeTyped(fd, type, value));
+        return modifyFile(server, uuid, nbt -> Services.PLAYER_DATA.writeOfflineServerData(nbt, type, value));
     }
 
     /**
@@ -119,21 +112,20 @@ public final class OfflinePlayerDataAccessor {
             consumer.accept(new OnlineView(online));
             return true;
         }
-        return modifyFile(server, uuid, fd -> consumer.accept(new FileView(fd)));
+        return modifyFile(server, uuid, nbt -> consumer.accept(new FileView(nbt)));
     }
 
     // ── File I/O ──────────────────────────────────────────────────────────────
 
     /**
-     * Load the {@code ForgeData} tag from a player's .dat file without writing
-     * back.  Returns empty if the file does not exist or cannot be read.
+     * Load the raw player NBT CompoundTag from disk without writing back.
+     * Returns empty if the file does not exist or cannot be read.
      */
-    private static Optional<CompoundTag> readForgeData(MinecraftServer server, UUID uuid) {
+    private static Optional<CompoundTag> readPlayerNbt(MinecraftServer server, UUID uuid) {
         Path file = resolvePlayerFile(server, uuid);
         if (!Files.exists(file)) return Optional.empty();
         try (var in = Files.newInputStream(file)) {
-            CompoundTag playerNbt = NbtIo.readCompressed(in, NbtAccounter.unlimitedHeap());
-            return playerNbt.getCompound(FORGE_DATA_KEY).map(fd -> fd);
+            return Optional.of(NbtIo.readCompressed(in, NbtAccounter.unlimitedHeap()));
         } catch (IOException e) {
             LOGGER.warn("[OfflinePlayerDataAccessor] Failed to read {}: {}", file, e.getMessage());
             return Optional.empty();
@@ -141,7 +133,7 @@ public final class OfflinePlayerDataAccessor {
     }
 
     /**
-     * Load → mutate → write the {@code ForgeData} tag for an offline player.
+     * Load → mutate → write the player NBT for an offline player.
      * If the file does not exist or a read/write error occurs, logs a warning
      * and returns {@code false}.
      */
@@ -153,10 +145,7 @@ public final class OfflinePlayerDataAccessor {
         }
         try (var in = Files.newInputStream(file)) {
             CompoundTag playerNbt = NbtIo.readCompressed(in, NbtAccounter.unlimitedHeap());
-            // Get existing ForgeData or create a new one
-            CompoundTag forgeData = playerNbt.getCompound(FORGE_DATA_KEY).orElseGet(CompoundTag::new);
-            mutation.accept(forgeData);
-            playerNbt.put(FORGE_DATA_KEY, forgeData);
+            mutation.accept(playerNbt);
             NbtIo.writeCompressed(playerNbt, file);
             return true;
         } catch (IOException e) {
@@ -166,33 +155,13 @@ public final class OfflinePlayerDataAccessor {
     }
 
     /**
-     * Resolves the path to a player's .dat file.
-     * NeoForge stores player data at {@code <level_root>/playerdata/<uuid>.dat}.
+     * Resolves the path to a player's .dat file at
+     * {@code <level_root>/playerdata/<uuid>.dat}.
      */
     private static Path resolvePlayerFile(MinecraftServer server, UUID uuid) {
         return server.getWorldPath(LevelResource.ROOT)
                 .resolve("playerdata")
                 .resolve(uuid.toString() + ".dat");
-    }
-
-    // ── Codec helpers (mirrors NeoForgePlayerDataHelper private methods) ───────
-
-    private static <T> Optional<T> readTyped(CompoundTag forgeData, PlayerServerDataType<T> type) {
-        String key = SDATA_PREFIX + type.id().toString();
-        Tag raw = forgeData.get(key);
-        if (!(raw instanceof CompoundTag wrapper)) return Optional.empty();
-        Tag inner = wrapper.get("v");
-        if (inner == null) return Optional.empty();
-        return type.nbtCodec().parse(NbtOps.INSTANCE, inner).result();
-    }
-
-    private static <T> void writeTyped(CompoundTag forgeData, PlayerServerDataType<T> type, T value) {
-        String key = SDATA_PREFIX + type.id().toString();
-        type.nbtCodec().encodeStart(NbtOps.INSTANCE, value).result().ifPresent(tag -> {
-            CompoundTag wrapper = new CompoundTag();
-            wrapper.put("v", tag);
-            forgeData.put(key, wrapper);
-        });
     }
 
     // ── OfflinePlayerData view implementations ────────────────────────────────
@@ -217,25 +186,26 @@ public final class OfflinePlayerDataAccessor {
     }
 
     /**
-     * Offline view: reads from / writes to an in-memory {@link CompoundTag}.
-     * The {@link OfflinePlayerDataAccessor#modifyFile} caller saves the tag to
+     * Offline view: reads from / writes to an in-memory player NBT
+     * {@link CompoundTag}.  The {@link #modifyFile} caller writes it back to
      * disk after the consumer returns.
      */
     private static final class FileView implements OfflinePlayerData {
-        private final CompoundTag forgeData;
+        private final CompoundTag playerNbt;
 
-        FileView(CompoundTag forgeData) { this.forgeData = forgeData; }
+        FileView(CompoundTag playerNbt) { this.playerNbt = playerNbt; }
 
         @Override public boolean isOnline() { return false; }
 
         @Override
         public <T> T get(PlayerServerDataType<T> type) {
-            return readTyped(forgeData, type).orElse(type.defaultFactory().get());
+            return Services.PLAYER_DATA.readOfflineServerData(playerNbt, type).orElse(type.defaultFactory().get());
         }
 
         @Override
         public <T> void set(PlayerServerDataType<T> type, T value) {
-            writeTyped(forgeData, type, value);
+            Services.PLAYER_DATA.writeOfflineServerData(playerNbt, type, value);
         }
     }
 }
+

--- a/common/src/main/java/net/creeperhost/polylib/player/serverdata/offline/OfflinePlayerDataAccessor.java
+++ b/common/src/main/java/net/creeperhost/polylib/player/serverdata/offline/OfflinePlayerDataAccessor.java
@@ -1,0 +1,241 @@
+package net.creeperhost.polylib.player.serverdata.offline;
+
+import net.creeperhost.polylib.player.serverdata.PlayerServerDataManager;
+import net.creeperhost.polylib.player.serverdata.PlayerServerDataType;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.NbtAccounter;
+import net.minecraft.nbt.NbtIo;
+import net.minecraft.nbt.NbtOps;
+import net.minecraft.nbt.Tag;
+import net.minecraft.world.level.storage.LevelResource;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerPlayer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Consumer;
+
+/**
+ * Read/write PolyLib {@link PlayerServerDataType} values for both online and
+ * offline players.
+ *
+ * <h2>Online players</h2>
+ * All operations delegate to the live
+ * {@link PlayerServerDataManager} so the in-memory store is never bypassed.
+ *
+ * <h2>Offline players</h2>
+ * Data is read from / written to the player's {@code .dat} file at
+ * {@code <world>/playerdata/<uuid>.dat}.  On NeoForge, PolyLib persists
+ * server-data values inside the player's {@code ForgeData} compound under keys
+ * of the form {@code polylib_sdata.<typeId>}.
+ *
+ * <h2>Thread safety</h2>
+ * Must be called from the server tick thread.  No locking is performed because
+ * Minecraft's server is single-threaded; concurrent calls from other threads
+ * (e.g. the network thread) are unsafe regardless.
+ *
+ * <h2>Usage example</h2>
+ * <pre>{@code
+ * // One-shot read (returns default if no data)
+ * PlayerAbilities ab = OfflinePlayerDataAccessor.get(server, uuid, ModPlayerData.PLAYER_ABILITIES);
+ *
+ * // One-shot write
+ * OfflinePlayerDataAccessor.set(server, uuid, ModPlayerData.PLAYER_ABILITIES, newAbilities);
+ *
+ * // Atomic read-modify-write (single file I/O pass for offline players)
+ * OfflinePlayerDataAccessor.modify(server, uuid, data -> {
+ *     PlayerAbilities ab = data.get(ModPlayerData.PLAYER_ABILITIES);
+ *     ab.addPower(SomePower.ID);
+ *     data.set(ModPlayerData.PLAYER_ABILITIES, ab);
+ * });
+ * }</pre>
+ */
+public final class OfflinePlayerDataAccessor {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(OfflinePlayerDataAccessor.class);
+
+    /** Key inside the player .dat CompoundTag where NeoForge stores getPersistentData(). */
+    private static final String FORGE_DATA_KEY = "ForgeData";
+
+    /** Key prefix PolyLib uses for server-data types inside ForgeData. */
+    private static final String SDATA_PREFIX = "polylib_sdata.";
+
+    private OfflinePlayerDataAccessor() {}
+
+    // ── Public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Read one data type for a player (online or offline).
+     * Returns the type's default if the player has no saved value.
+     *
+     * @param server the running server instance
+     * @param uuid   target player UUID
+     * @param type   the data type to read
+     */
+    public static <T> T get(MinecraftServer server, UUID uuid, PlayerServerDataType<T> type) {
+        ServerPlayer online = server.getPlayerList().getPlayer(uuid);
+        if (online != null) return PlayerServerDataManager.get(online, type);
+
+        return readForgeData(server, uuid)
+                .map(fd -> readTyped(fd, type).orElse(type.defaultFactory().get()))
+                .orElse(type.defaultFactory().get());
+    }
+
+    /**
+     * Write one data type for a player (online or offline).
+     * For online players, also syncs if the type has a sync codec.
+     *
+     * @return {@code true} if the write succeeded; {@code false} if the player
+     *         file was not found or an I/O error occurred.
+     */
+    public static <T> boolean set(MinecraftServer server, UUID uuid, PlayerServerDataType<T> type, T value) {
+        ServerPlayer online = server.getPlayerList().getPlayer(uuid);
+        if (online != null) {
+            PlayerServerDataManager.set(online, type, value);
+            return true;
+        }
+        return modifyFile(server, uuid, fd -> writeTyped(fd, type, value));
+    }
+
+    /**
+     * Atomic read-modify-write in a single file I/O pass (offline) or direct
+     * store access (online).
+     *
+     * <p>The supplied {@code consumer} receives an {@link OfflinePlayerData} view.
+     * Call {@link OfflinePlayerData#get} and {@link OfflinePlayerData#set} freely
+     * inside it; for offline players the file is written once when the consumer
+     * returns.
+     *
+     * @return {@code true} if the operation succeeded.
+     */
+    public static boolean modify(MinecraftServer server, UUID uuid, Consumer<OfflinePlayerData> consumer) {
+        ServerPlayer online = server.getPlayerList().getPlayer(uuid);
+        if (online != null) {
+            consumer.accept(new OnlineView(online));
+            return true;
+        }
+        return modifyFile(server, uuid, fd -> consumer.accept(new FileView(fd)));
+    }
+
+    // ── File I/O ──────────────────────────────────────────────────────────────
+
+    /**
+     * Load the {@code ForgeData} tag from a player's .dat file without writing
+     * back.  Returns empty if the file does not exist or cannot be read.
+     */
+    private static Optional<CompoundTag> readForgeData(MinecraftServer server, UUID uuid) {
+        Path file = resolvePlayerFile(server, uuid);
+        if (!Files.exists(file)) return Optional.empty();
+        try (var in = Files.newInputStream(file)) {
+            CompoundTag playerNbt = NbtIo.readCompressed(in, NbtAccounter.unlimitedHeap());
+            return playerNbt.getCompound(FORGE_DATA_KEY).map(fd -> fd);
+        } catch (IOException e) {
+            LOGGER.warn("[OfflinePlayerDataAccessor] Failed to read {}: {}", file, e.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Load → mutate → write the {@code ForgeData} tag for an offline player.
+     * If the file does not exist or a read/write error occurs, logs a warning
+     * and returns {@code false}.
+     */
+    private static boolean modifyFile(MinecraftServer server, UUID uuid, Consumer<CompoundTag> mutation) {
+        Path file = resolvePlayerFile(server, uuid);
+        if (!Files.exists(file)) {
+            LOGGER.warn("[OfflinePlayerDataAccessor] Player file not found for {}", uuid);
+            return false;
+        }
+        try (var in = Files.newInputStream(file)) {
+            CompoundTag playerNbt = NbtIo.readCompressed(in, NbtAccounter.unlimitedHeap());
+            // Get existing ForgeData or create a new one
+            CompoundTag forgeData = playerNbt.getCompound(FORGE_DATA_KEY).orElseGet(CompoundTag::new);
+            mutation.accept(forgeData);
+            playerNbt.put(FORGE_DATA_KEY, forgeData);
+            NbtIo.writeCompressed(playerNbt, file);
+            return true;
+        } catch (IOException e) {
+            LOGGER.warn("[OfflinePlayerDataAccessor] Failed to modify {}: {}", file, e.getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * Resolves the path to a player's .dat file.
+     * NeoForge stores player data at {@code <level_root>/playerdata/<uuid>.dat}.
+     */
+    private static Path resolvePlayerFile(MinecraftServer server, UUID uuid) {
+        return server.getWorldPath(LevelResource.ROOT)
+                .resolve("playerdata")
+                .resolve(uuid.toString() + ".dat");
+    }
+
+    // ── Codec helpers (mirrors NeoForgePlayerDataHelper private methods) ───────
+
+    private static <T> Optional<T> readTyped(CompoundTag forgeData, PlayerServerDataType<T> type) {
+        String key = SDATA_PREFIX + type.id().toString();
+        Tag raw = forgeData.get(key);
+        if (!(raw instanceof CompoundTag wrapper)) return Optional.empty();
+        Tag inner = wrapper.get("v");
+        if (inner == null) return Optional.empty();
+        return type.nbtCodec().parse(NbtOps.INSTANCE, inner).result();
+    }
+
+    private static <T> void writeTyped(CompoundTag forgeData, PlayerServerDataType<T> type, T value) {
+        String key = SDATA_PREFIX + type.id().toString();
+        type.nbtCodec().encodeStart(NbtOps.INSTANCE, value).result().ifPresent(tag -> {
+            CompoundTag wrapper = new CompoundTag();
+            wrapper.put("v", tag);
+            forgeData.put(key, wrapper);
+        });
+    }
+
+    // ── OfflinePlayerData view implementations ────────────────────────────────
+
+    /** Online view: delegates directly to the live PlayerServerDataManager. */
+    private static final class OnlineView implements OfflinePlayerData {
+        private final ServerPlayer player;
+
+        OnlineView(ServerPlayer player) { this.player = player; }
+
+        @Override public boolean isOnline() { return true; }
+
+        @Override
+        public <T> T get(PlayerServerDataType<T> type) {
+            return PlayerServerDataManager.get(player, type);
+        }
+
+        @Override
+        public <T> void set(PlayerServerDataType<T> type, T value) {
+            PlayerServerDataManager.set(player, type, value);
+        }
+    }
+
+    /**
+     * Offline view: reads from / writes to an in-memory {@link CompoundTag}.
+     * The {@link OfflinePlayerDataAccessor#modifyFile} caller saves the tag to
+     * disk after the consumer returns.
+     */
+    private static final class FileView implements OfflinePlayerData {
+        private final CompoundTag forgeData;
+
+        FileView(CompoundTag forgeData) { this.forgeData = forgeData; }
+
+        @Override public boolean isOnline() { return false; }
+
+        @Override
+        public <T> T get(PlayerServerDataType<T> type) {
+            return readTyped(forgeData, type).orElse(type.defaultFactory().get());
+        }
+
+        @Override
+        public <T> void set(PlayerServerDataType<T> type, T value) {
+            writeTyped(forgeData, type, value);
+        }
+    }
+}

--- a/fabric/src/main/java/net/creeperhost/polylib/PolyLibFabric.java
+++ b/fabric/src/main/java/net/creeperhost/polylib/PolyLibFabric.java
@@ -16,6 +16,7 @@ public class PolyLibFabric implements ModInitializer
     public void onInitialize()
     {
         FabricEvents.init();
+        FabricServerEvents.register();
         PolylibCommon.registerConfig();
         PolylibCommon.init();
         FabricInventoryManager.init();

--- a/fabric/src/main/java/net/creeperhost/polylib/platform/FabricPlayerDataHelper.java
+++ b/fabric/src/main/java/net/creeperhost/polylib/platform/FabricPlayerDataHelper.java
@@ -11,6 +11,9 @@ import net.creeperhost.polylib.player.settings.PlayerClientSettingsStore;
 import net.creeperhost.polylib.player.settings.PlayerClientSettingsType;
 import net.fabricmc.fabric.api.attachment.v1.AttachmentRegistry;
 import net.fabricmc.fabric.api.attachment.v1.AttachmentType;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.NbtOps;
+import net.minecraft.nbt.Tag;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.resources.Identifier;
 import net.minecraft.server.level.ServerPlayer;
@@ -18,6 +21,7 @@ import net.minecraft.server.level.ServerPlayer;
 import java.nio.ByteBuffer;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
 /**
@@ -188,6 +192,32 @@ public class FabricPlayerDataHelper implements IPlayerDataHelper
         if (attachment == null) return;  // type registered after Fabric AttachmentRegistry locked — can't lazy-load
         T value = player.getAttached(attachment);
         if (value != null) store.load(type, value);
+    }
+
+    // Fabric stores AttachmentType values in the player .dat file under "fabric:attachments"
+    private static final String FABRIC_ATTACHMENTS_KEY = "fabric:attachments";
+
+    @Override
+    public <T> Optional<T> readOfflineServerData(CompoundTag playerNbt, PlayerServerDataType<T> type)
+    {
+        Identifier attachId = Identifier.fromNamespaceAndPath(Constants.MOD_ID,
+                "sdata/" + type.id().getNamespace() + "/" + type.id().getPath());
+        CompoundTag attachments = playerNbt.getCompound(FABRIC_ATTACHMENTS_KEY).orElse(null);
+        if (attachments == null) return Optional.empty();
+        Tag raw = attachments.get(attachId.toString());
+        if (raw == null) return Optional.empty();
+        return type.nbtCodec().parse(NbtOps.INSTANCE, raw).result();
+    }
+
+    @Override
+    public <T> void writeOfflineServerData(CompoundTag playerNbt, PlayerServerDataType<T> type, T value)
+    {
+        Identifier attachId = Identifier.fromNamespaceAndPath(Constants.MOD_ID,
+                "sdata/" + type.id().getNamespace() + "/" + type.id().getPath());
+        CompoundTag attachments = playerNbt.getCompound(FABRIC_ATTACHMENTS_KEY).orElseGet(CompoundTag::new);
+        type.nbtCodec().encodeStart(NbtOps.INSTANCE, value).result().ifPresent(tag ->
+                attachments.put(attachId.toString(), tag));
+        playerNbt.put(FABRIC_ATTACHMENTS_KEY, attachments);
     }
 }
 

--- a/neoforge/src/main/java/net/creeperhost/polylib/platform/NeoForgePlayerDataHelper.java
+++ b/neoforge/src/main/java/net/creeperhost/polylib/platform/NeoForgePlayerDataHelper.java
@@ -17,6 +17,7 @@ import net.minecraft.server.level.ServerPlayer;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
 /**
@@ -174,6 +175,35 @@ public class NeoForgePlayerDataHelper implements IPlayerDataHelper
             if (inner != null)
                 loadServerTyped(type, inner, store);
         }
+    }
+
+    // NeoForge stores getPersistentData() under "ForgeData" inside the player .dat file
+    private static final String FORGE_DATA_KEY = "ForgeData";
+
+    @Override
+    public <T> Optional<T> readOfflineServerData(CompoundTag playerNbt, PlayerServerDataType<T> type)
+    {
+        CompoundTag forgeData = playerNbt.getCompound(FORGE_DATA_KEY).orElse(null);
+        if (forgeData == null) return Optional.empty();
+        String key = SDATA_PREFIX + type.id().toString();
+        Tag raw = forgeData.get(key);
+        if (!(raw instanceof CompoundTag wrapper)) return Optional.empty();
+        Tag inner = wrapper.get("v");
+        if (inner == null) return Optional.empty();
+        return type.nbtCodec().parse(NbtOps.INSTANCE, inner).result();
+    }
+
+    @Override
+    public <T> void writeOfflineServerData(CompoundTag playerNbt, PlayerServerDataType<T> type, T value)
+    {
+        CompoundTag forgeData = playerNbt.getCompound(FORGE_DATA_KEY).orElseGet(CompoundTag::new);
+        String key = SDATA_PREFIX + type.id().toString();
+        type.nbtCodec().encodeStart(NbtOps.INSTANCE, value).result().ifPresent(tag -> {
+            CompoundTag wrapper = new CompoundTag();
+            wrapper.put("v", tag);
+            forgeData.put(key, wrapper);
+        });
+        playerNbt.put(FORGE_DATA_KEY, forgeData);
     }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -27,7 +27,7 @@ include('common')
 include('fabric')
 include('neoforge')
 
-//include('testmod-common')
-//include('testmod-fabric')
-//include('testmod-neoforge')
+include('testmod-common')
+include('testmod-fabric')
+include('testmod-neoforge')
 

--- a/testmod-common/src/main/java/net/creeperhost/testmod/init/TestCommands.java
+++ b/testmod-common/src/main/java/net/creeperhost/testmod/init/TestCommands.java
@@ -1,14 +1,20 @@
 package net.creeperhost.testmod.init;
 
 import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.arguments.IntegerArgumentType;
+import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.context.CommandContext;
 import net.creeperhost.polylib.event.events.server.PolyServerCommandEvents;
+import net.creeperhost.polylib.player.serverdata.PlayerServerDataManager;
+import net.creeperhost.polylib.player.serverdata.offline.OfflinePlayerDataAccessor;
+import net.creeperhost.testmod.TestModCommon;
 import net.minecraft.commands.CommandBuildContext;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.network.chat.Component;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.damagesource.DamageSource;
@@ -27,6 +33,7 @@ import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.piston.PistonBaseBlock;
 import net.minecraft.world.level.storage.LevelData;
 import net.minecraft.world.phys.Vec3;
+import java.util.UUID;
 import static net.creeperhost.testmod.TestModCommon.LOGGER;
 
 /**
@@ -91,6 +98,13 @@ public final class TestCommands
                 .then(Commands.literal("multiplace").executes(TestCommands::testMultiPlace))
                 .then(Commands.literal("brewing").executes(TestCommands::testBrewing))
                 .then(Commands.literal("help").executes(TestCommands::testHelp))
+                // offline player data test
+                .then(Commands.literal("offlinedata")
+                        .then(Commands.literal("set")
+                                .then(Commands.argument("value", IntegerArgumentType.integer())
+                                        .executes(TestCommands::testOfflineDataSet)))
+                        .then(Commands.argument("player", StringArgumentType.word())
+                                .executes(TestCommands::testOfflineData)))
         );
     }
 
@@ -957,6 +971,67 @@ public final class TestCommands
         src.sendSuccess(() -> Component.literal("  §fTier 1: §7living, block, effects, entity, explosion, conversion, tick, spawn, sleep, bow, xp"), false);
         src.sendSuccess(() -> Component.literal("  §fTier 3+: §7damage, fall, attack, equip, projectile, lightning, teleport, breed, split, piston, noteblock, fluid, portal, gamemode, setspawn, item, useitem, multiplace, brewing"), false);
         src.sendSuccess(() -> Component.literal("  §fInfo: §7passive (auto-firing events), manual (gameplay-required events), help"), false);
+        src.sendSuccess(() -> Component.literal("  §fOffline: §7offlinedata set <n>  |  offlinedata <name|uuid>"), false);
         return 1;
+    }
+
+    // =========================================================================
+    // Offline player data
+    // =========================================================================
+
+    // ----- /polytest offlinedata set <value> -----
+    // Writes TICKS_PLAYED for the calling player so the read can be verified
+
+    private static int testOfflineDataSet(CommandContext<CommandSourceStack> ctx)
+    {
+        CommandSourceStack src = ctx.getSource();
+        int value = IntegerArgumentType.getInteger(ctx, "value");
+        try
+        {
+            ServerPlayer player = src.getPlayerOrException();
+            PlayerServerDataManager.set(player, TestModCommon.TICKS_PLAYED, value);
+            src.sendSuccess(() -> Component.literal("[polytest] offlinedata: TICKS_PLAYED set to " + value + " — run /polytest offlinedata " + player.getScoreboardName() + " to verify"), false);
+        }
+        catch (Exception e)
+        {
+            src.sendFailure(Component.literal("[polytest] offlinedata set: must be a player: " + e.getMessage()));
+        }
+        return 1;
+    }
+
+    // ----- /polytest offlinedata <player> -----
+    // Reads TICKS_PLAYED from the player's server data (works even when offline)
+
+    private static int testOfflineData(CommandContext<CommandSourceStack> ctx)
+    {
+        CommandSourceStack src = ctx.getSource();
+        String name = StringArgumentType.getString(ctx, "player");
+        MinecraftServer server = ctx.getSource().getServer();
+
+        // Try online players first
+        ServerPlayer online = server.getPlayerList().getPlayers().stream()
+                .filter(p -> p.getScoreboardName().equalsIgnoreCase(name))
+                .findFirst()
+                .orElse(null);
+
+        if (online != null)
+        {
+            Integer ticks = OfflinePlayerDataAccessor.get(server, online.getUUID(), TestModCommon.TICKS_PLAYED);
+            src.sendSuccess(() -> Component.literal("[polytest] offlinedata: " + name + " (online) TICKS_PLAYED=" + ticks), false);
+            return 1;
+        }
+
+        // Try parsing the argument as a UUID directly (for offline player testing)
+        try
+        {
+            UUID uuid = UUID.fromString(name);
+            Integer ticks = OfflinePlayerDataAccessor.get(server, uuid, TestModCommon.TICKS_PLAYED);
+            src.sendSuccess(() -> Component.literal("[polytest] offlinedata: " + uuid + " (offline/uuid) TICKS_PLAYED=" + ticks), false);
+            return 1;
+        }
+        catch (IllegalArgumentException ignored) {}
+
+        src.sendFailure(Component.literal("[polytest] offlinedata: '" + name + "' is not online. Pass a UUID string to test offline lookup."));
+        return 0;
     }
 }


### PR DESCRIPTION
Adds \OfflinePlayerDataAccessor\ — a utility for reading and writing \PlayerServerDataType\ values from a player's \.dat\ file without requiring the player to be online.

**New classes**
- \OfflinePlayerData\ — interface for read/write access to a player's server-data store (online or offline)
- \OfflinePlayerDataAccessor\ — static utility with \get\, \set\, and \modify\ methods:
  - Online players: delegates to the live \PlayerServerDataManager\ (no file I/O)
  - Offline players: reads/writes the \<world>/playerdata/<uuid>.dat\ file directly

**Testmod**
- \/polytest offlinedata <name>\ — reads \TICKS_PLAYED\ for an online player by name
- \/polytest offlinedata <uuid>\ — reads \TICKS_PLAYED\ from the \.dat\ file for an offline player (pass UUID string)
- \/polytest offlinedata set <n>\ — writes \TICKS_PLAYED\ for the calling player so round-trip can be verified

**Verified in NeoForge testmod:** \TICKS_PLAYED=0\ returned correctly for a fresh player. Use \set\ then \get\ to verify round-trip.