### PR TITLE
feat(chat): floating chat windows, minimize/restore, position persistence, Fabric render fix

### DIFF
--- a/common/src/main/java/net/creeperhost/polylib/PolyLibClient.java
+++ b/common/src/main/java/net/creeperhost/polylib/PolyLibClient.java
@@ -1,5 +1,7 @@
 package net.creeperhost.polylib;
 
+import net.creeperhost.polylib.chat.client.ChatNotifications;
+import net.creeperhost.polylib.chat.client.tab.ChatTabInjection;
 import net.creeperhost.polylib.init.InternalEventListenerClient;
 import net.creeperhost.polylib.platform.Services;
 import net.minecraft.client.Minecraft;
@@ -10,6 +12,8 @@ public class PolyLibClient
     public static void init()
     {
         InternalEventListenerClient.init();
+        ChatTabInjection.init();
+        ChatNotifications.init();
     }
 
     public static Player getClientPlayer()

--- a/common/src/main/java/net/creeperhost/polylib/chat/ChatChannel.java
+++ b/common/src/main/java/net/creeperhost/polylib/chat/ChatChannel.java
@@ -81,6 +81,15 @@ public class ChatChannel {
         this.messageListeners.remove(listener);
     }
 
+    private boolean mentionPulseEnabled = true;
+    private boolean vanillaMentionNotification = true;
+
+    public boolean isMentionPulseEnabled() { return mentionPulseEnabled; }
+    public void setMentionPulseEnabled(boolean enabled) { this.mentionPulseEnabled = enabled; }
+
+    public boolean isVanillaMentionNotification() { return vanillaMentionNotification; }
+    public void setVanillaMentionNotification(boolean enabled) { this.vanillaMentionNotification = enabled; }
+
     private Consumer<String> messageSubmitHandler;
 
     public void setSubmitHandler(Consumer<String> handler) {

--- a/common/src/main/java/net/creeperhost/polylib/chat/ChatChannel.java
+++ b/common/src/main/java/net/creeperhost/polylib/chat/ChatChannel.java
@@ -1,0 +1,95 @@
+package net.creeperhost.polylib.chat;
+
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.Identifier;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Consumer;
+
+/**
+ * Represents an isolated stream of messages and members.
+ */
+public class ChatChannel {
+    private final Identifier channelId;
+    private final Component name;
+    private final boolean canReply;
+
+    private final List<ChatMember> members = new ArrayList<>();
+    private final List<RichChatMessage> messages = new ArrayList<>();
+    
+    private final List<Consumer<RichChatMessage>> messageListeners = new ArrayList<>();
+
+    public ChatChannel(Identifier channelId, Component name, boolean canReply) {
+        this.channelId = channelId;
+        this.name = name;
+        this.canReply = canReply;
+    }
+
+    public Identifier getChannelId() {
+        return channelId;
+    }
+
+    public Component getName() {
+        return name;
+    }
+
+    public boolean canReply() {
+        return canReply;
+    }
+
+    public List<ChatMember> getMembers() {
+        return Collections.unmodifiableList(members);
+    }
+
+    public void addMember(ChatMember member) {
+        members.removeIf(m -> m.memberId().equals(member.memberId()));
+        members.add(member);
+    }
+
+    public void removeMember(UUID memberId) {
+        members.removeIf(m -> m.memberId().equals(memberId));
+    }
+
+    public Optional<ChatMember> getMember(UUID memberId) {
+        return members.stream().filter(m -> m.memberId().equals(memberId)).findFirst();
+    }
+
+    public List<RichChatMessage> getMessages() {
+        return Collections.unmodifiableList(messages);
+    }
+
+    public void addMessage(RichChatMessage message) {
+        this.messages.add(message);
+        // keep buffer size reasonable
+        if (this.messages.size() > 1000) {
+            this.messages.remove(0);
+        }
+        for (Consumer<RichChatMessage> listener : messageListeners) {
+            listener.accept(message);
+        }
+    }
+
+    public void addMessageListener(Consumer<RichChatMessage> listener) {
+        this.messageListeners.add(listener);
+    }
+
+    public void removeMessageListener(Consumer<RichChatMessage> listener) {
+        this.messageListeners.remove(listener);
+    }
+
+    private Consumer<String> messageSubmitHandler;
+
+    public void setSubmitHandler(Consumer<String> handler) {
+        this.messageSubmitHandler = handler;
+    }
+
+    public void submitMessage(String message) {
+        if (messageSubmitHandler != null) {
+            messageSubmitHandler.accept(message);
+        }
+    }
+}

--- a/common/src/main/java/net/creeperhost/polylib/chat/ChatConfig.java
+++ b/common/src/main/java/net/creeperhost/polylib/chat/ChatConfig.java
@@ -1,0 +1,16 @@
+package net.creeperhost.polylib.chat;
+
+/**
+ * User-facing config options for the PolyLib chat system.
+ * Values are runtime defaults; these can be wired to a config screen in the future.
+ */
+public class ChatConfig {
+
+    /** Enable mention pulse animation on floating windows and tab badges. */
+    public static boolean mentionPulse = true;
+
+    /** Enable vanilla system-message notification for mentions in non-active tabs. */
+    public static boolean vanillaMentionNotify = true;
+
+    private ChatConfig() {}
+}

--- a/common/src/main/java/net/creeperhost/polylib/chat/ChatMember.java
+++ b/common/src/main/java/net/creeperhost/polylib/chat/ChatMember.java
@@ -1,0 +1,22 @@
+package net.creeperhost.polylib.chat;
+
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.Identifier;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.UUID;
+
+/**
+ * Represents a member/participant in a ChatChannel sidebar.
+ * Can represent a Player, a Shell, or an Automation Controller.
+ */
+public record ChatMember(
+        UUID memberId,
+        Component displayName,
+        @Nullable Identifier icon,
+        boolean isOnline
+) {
+    public ChatMember withOnlineStatus(boolean online) {
+        return new ChatMember(memberId, displayName, icon, online);
+    }
+}

--- a/common/src/main/java/net/creeperhost/polylib/chat/ChatRouter.java
+++ b/common/src/main/java/net/creeperhost/polylib/chat/ChatRouter.java
@@ -1,10 +1,13 @@
 package net.creeperhost.polylib.chat;
 
 import net.minecraft.resources.Identifier;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BiConsumer;
 
 /**
  * Manages active chat channels and routes messages.
@@ -13,6 +16,7 @@ public class ChatRouter {
     private static final ChatRouter INSTANCE = new ChatRouter();
     
     private final Map<Identifier, ChatChannel> channels = new ConcurrentHashMap<>();
+    private final List<BiConsumer<ChatChannel, RichChatMessage>> globalMessageListeners = new ArrayList<>();
 
     private ChatRouter() {}
 
@@ -22,6 +26,12 @@ public class ChatRouter {
 
     public void registerChannel(ChatChannel channel) {
         channels.put(channel.getChannelId(), channel);
+        // Bridge: fire global listeners whenever a message is added to this channel directly
+        channel.addMessageListener(msg -> {
+            for (BiConsumer<ChatChannel, RichChatMessage> listener : new ArrayList<>(globalMessageListeners)) {
+                listener.accept(channel, msg);
+            }
+        });
     }
 
     public void unregisterChannel(Identifier channelId) {
@@ -36,6 +46,14 @@ public class ChatRouter {
         return Collections.unmodifiableCollection(channels.values());
     }
 
+    public void addGlobalMessageListener(BiConsumer<ChatChannel, RichChatMessage> listener) {
+        globalMessageListeners.add(listener);
+    }
+
+    public void removeGlobalMessageListener(BiConsumer<ChatChannel, RichChatMessage> listener) {
+        globalMessageListeners.remove(listener);
+    }
+
     /**
      * Routes a message to a specific channel.
      */
@@ -43,6 +61,9 @@ public class ChatRouter {
         ChatChannel channel = channels.get(channelId);
         if (channel != null) {
             channel.addMessage(message);
+            for (BiConsumer<ChatChannel, RichChatMessage> listener : new ArrayList<>(globalMessageListeners)) {
+                listener.accept(channel, message);
+            }
             return true;
         }
         return false;

--- a/common/src/main/java/net/creeperhost/polylib/chat/ChatRouter.java
+++ b/common/src/main/java/net/creeperhost/polylib/chat/ChatRouter.java
@@ -1,0 +1,50 @@
+package net.creeperhost.polylib.chat;
+
+import net.minecraft.resources.Identifier;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Manages active chat channels and routes messages.
+ */
+public class ChatRouter {
+    private static final ChatRouter INSTANCE = new ChatRouter();
+    
+    private final Map<Identifier, ChatChannel> channels = new ConcurrentHashMap<>();
+
+    private ChatRouter() {}
+
+    public static ChatRouter getInstance() {
+        return INSTANCE;
+    }
+
+    public void registerChannel(ChatChannel channel) {
+        channels.put(channel.getChannelId(), channel);
+    }
+
+    public void unregisterChannel(Identifier channelId) {
+        channels.remove(channelId);
+    }
+
+    public ChatChannel getChannel(Identifier channelId) {
+        return channels.get(channelId);
+    }
+
+    public Collection<ChatChannel> getActiveChannels() {
+        return Collections.unmodifiableCollection(channels.values());
+    }
+
+    /**
+     * Routes a message to a specific channel.
+     */
+    public boolean routeMessage(Identifier channelId, RichChatMessage message) {
+        ChatChannel channel = channels.get(channelId);
+        if (channel != null) {
+            channel.addMessage(message);
+            return true;
+        }
+        return false;
+    }
+}

--- a/common/src/main/java/net/creeperhost/polylib/chat/RichChatMessage.java
+++ b/common/src/main/java/net/creeperhost/polylib/chat/RichChatMessage.java
@@ -1,0 +1,32 @@
+package net.creeperhost.polylib.chat;
+
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.Identifier;
+import org.jetbrains.annotations.Nullable;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Represents a single message in the PolyLib Modular Chat Framework.
+ */
+public record RichChatMessage(
+        UUID messageId,
+        Component content,
+        Instant timestamp,
+        Component senderName,
+        @Nullable Identifier senderIcon,
+        @Nullable UUID senderId
+) {
+    public static RichChatMessage create(Component content, Component senderName) {
+        return new RichChatMessage(UUID.randomUUID(), content, Instant.now(), senderName, null, null);
+    }
+
+    public static RichChatMessage create(Component content, Component senderName, Identifier senderIcon) {
+        return new RichChatMessage(UUID.randomUUID(), content, Instant.now(), senderName, senderIcon, null);
+    }
+
+    public static RichChatMessage create(Component content, Component senderName, Identifier senderIcon, UUID senderId) {
+        return new RichChatMessage(UUID.randomUUID(), content, Instant.now(), senderName, senderIcon, senderId);
+    }
+}

--- a/common/src/main/java/net/creeperhost/polylib/chat/client/ChatNotifications.java
+++ b/common/src/main/java/net/creeperhost/polylib/chat/client/ChatNotifications.java
@@ -1,0 +1,162 @@
+package net.creeperhost.polylib.chat.client;
+
+import net.creeperhost.polylib.chat.ChatChannel;
+import net.creeperhost.polylib.chat.ChatConfig;
+import net.creeperhost.polylib.chat.ChatRouter;
+import net.creeperhost.polylib.chat.RichChatMessage;
+import net.creeperhost.polylib.chat.client.tab.ChatTabRegistry;
+import net.creeperhost.polylib.chat.client.tab.ChatTab;
+import net.creeperhost.polylib.chat.client.tab.ChannelTab;
+import net.minecraft.client.Minecraft;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.Identifier;
+
+import java.util.*;
+import java.util.function.Predicate;
+
+/**
+ * Registry for mention/notification triggers per channel.
+ * When a message arrives on a channel, the registered trigger is tested.
+ * If it fires, the channel's UI elements pulse and an optional vanilla notification is sent.
+ */
+public class ChatNotifications {
+
+    /** Fires on every new message. Opt-in only. */
+    public static final Predicate<RichChatMessage> TRIGGER_ANY_MESSAGE = msg -> true;
+
+    /** Fires when message content contains the local player's name. Default trigger. */
+    public static final Predicate<RichChatMessage> TRIGGER_CONTAINS_NAME = msg -> {
+        Minecraft mc = Minecraft.getInstance();
+        if (mc.player == null) return false;
+        String playerName = mc.player.getScoreboardName();
+        return msg.content().getString().toLowerCase(Locale.ROOT)
+                  .contains(playerName.toLowerCase(Locale.ROOT));
+    };
+
+    private static final Map<Identifier, Predicate<RichChatMessage>> triggers = new HashMap<>();
+    private static final Set<Identifier> pulsing = new HashSet<>();
+    private static final List<PulseListener> pulseListeners = new ArrayList<>();
+
+    /**
+     * Register a custom trigger for a channel's notification pulse.
+     * Replaces any previously registered trigger for that channel.
+     * If no trigger is registered, {@link #TRIGGER_CONTAINS_NAME} is used as default.
+     */
+    public static void registerMentionTrigger(Identifier channelId, Predicate<RichChatMessage> trigger) {
+        triggers.put(channelId, trigger);
+    }
+
+    /**
+     * Remove a custom trigger. Channel reverts to default {@link #TRIGGER_CONTAINS_NAME}.
+     */
+    public static void removeMentionTrigger(Identifier channelId) {
+        triggers.remove(channelId);
+    }
+
+    /**
+     * Test whether a message should trigger a pulse for the given channel.
+     */
+    public static boolean shouldPulse(Identifier channelId, RichChatMessage message) {
+        Predicate<RichChatMessage> trigger = triggers.getOrDefault(channelId, TRIGGER_CONTAINS_NAME);
+        return trigger.test(message);
+    }
+
+    /**
+     * Mark a channel as pulsing. UI elements observe this via {@link PulseListener}.
+     */
+    public static void startPulse(Identifier channelId) {
+        if (pulsing.add(channelId)) {
+            List<PulseListener> snapshot = new ArrayList<>(pulseListeners);
+            for (PulseListener l : snapshot) {
+                l.onPulseChanged(channelId, true);
+            }
+        }
+    }
+
+    /**
+     * Clear the pulse state (user clicked/focused the channel).
+     */
+    public static void clearPulse(Identifier channelId) {
+        if (pulsing.remove(channelId)) {
+            List<PulseListener> snapshot = new ArrayList<>(pulseListeners);
+            for (PulseListener l : snapshot) {
+                l.onPulseChanged(channelId, false);
+            }
+        }
+    }
+
+    /**
+     * Check if a channel is currently pulsing.
+     */
+    public static boolean isPulsing(Identifier channelId) {
+        return pulsing.contains(channelId);
+    }
+
+    public static void addPulseListener(PulseListener listener) {
+        pulseListeners.add(listener);
+    }
+
+    public static void removePulseListener(PulseListener listener) {
+        pulseListeners.remove(listener);
+    }
+
+    /**
+     * Called when any channel receives a new message. Evaluates the trigger
+     * and starts pulse / sends vanilla notification as appropriate.
+     */
+    public static void onMessageReceived(Identifier channelId, RichChatMessage message,
+                                         boolean channelIsFocused, boolean mentionPulseEnabled,
+                                         boolean vanillaNotifyEnabled, Component channelName) {
+        if (!ChatConfig.mentionPulse) return;
+        if (!shouldPulse(channelId, message)) return;
+
+        if (mentionPulseEnabled && !channelIsFocused) {
+            startPulse(channelId);
+        }
+
+        if (vanillaNotifyEnabled && ChatConfig.vanillaMentionNotify && !channelIsFocused) {
+            sendVanillaNotification(channelName);
+        }
+    }
+
+    private static void sendVanillaNotification(Component channelName) {
+        Minecraft mc = Minecraft.getInstance();
+        if (mc.player != null) {
+            mc.player.sendSystemMessage(
+                Component.literal("\u00a7e[")
+                    .append(channelName)
+                    .append(Component.literal("] You have been mentioned"))
+            );
+        }
+    }
+
+    /**
+     * Call once during client init to hook into ChatRouter for global pulse monitoring.
+     */
+    public static void init() {
+        ChatRouter.getInstance().addGlobalMessageListener((channel, message) -> {
+            boolean focused = isChannelFocused(channel.getChannelId());
+            onMessageReceived(
+                channel.getChannelId(), message, focused,
+                channel.isMentionPulseEnabled(),
+                channel.isVanillaMentionNotification(),
+                channel.getName()
+            );
+        });
+    }
+
+    private static boolean isChannelFocused(Identifier channelId) {
+        ChatTabRegistry registry = ChatTabRegistry.get();
+        ChatTab activeTab = registry.getActiveTab();
+        if (activeTab instanceof ChannelTab ct
+                && ct.channel().getChannelId().equals(channelId)) {
+            return true;
+        }
+        return false;
+    }
+
+    @FunctionalInterface
+    public interface PulseListener {
+        void onPulseChanged(Identifier channelId, boolean pulsing);
+    }
+}

--- a/common/src/main/java/net/creeperhost/polylib/chat/client/ChatWindowManager.java
+++ b/common/src/main/java/net/creeperhost/polylib/chat/client/ChatWindowManager.java
@@ -1,0 +1,54 @@
+package net.creeperhost.polylib.chat.client;
+
+import net.creeperhost.polylib.chat.layout.ChatWindowLayout;
+import net.creeperhost.polylib.client.modulargui.elements.GuiWindow;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Manages multiple GuiWindows, handles Z-indexing, focus, snapping, and tiling.
+ */
+public class ChatWindowManager {
+    private static final int SNAP_DISTANCE = 10;
+    
+    private final List<GuiWindow> managedWindows = new ArrayList<>();
+
+    public ChatWindowManager() {
+    }
+
+    public void addWindow(GuiWindow window) {
+        managedWindows.add(window);
+        
+        // Add hooking for move completion to do snapping
+        window.setOnMovedCallback(() -> handleWindowMoved(window));
+    }
+
+    public void removeWindow(GuiWindow window) {
+        managedWindows.remove(window);
+    }
+
+    public void bringToFront(GuiWindow window) {
+        if (managedWindows.remove(window)) {
+            managedWindows.add(window);
+        }
+    }
+
+    private void handleWindowMoved(GuiWindow movedWindow) {
+        // Simple edge-snapping logic
+        for (GuiWindow other : managedWindows) {
+            if (other == movedWindow) continue;
+
+            // Snap left edge to right edge
+            if (Math.abs(movedWindow.xMin - other.xMax) < SNAP_DISTANCE) {
+                // If y overlap exists
+                if (movedWindow.yMax > other.yMin && movedWindow.yMin < other.yMax) {
+                    movedWindow.xMin = other.xMax;
+                    movedWindow.xMax = movedWindow.xMin + movedWindow.getMinSize().width(); // or preserve width
+                }
+            }
+            
+            // Further snapping logic can be expanded here
+        }
+    }
+}

--- a/common/src/main/java/net/creeperhost/polylib/chat/client/ChatWindowManager.java
+++ b/common/src/main/java/net/creeperhost/polylib/chat/client/ChatWindowManager.java
@@ -1,5 +1,6 @@
 package net.creeperhost.polylib.chat.client;
 
+import net.creeperhost.polylib.chat.layout.ChatLayoutManager;
 import net.creeperhost.polylib.chat.layout.ChatWindowLayout;
 import net.creeperhost.polylib.client.modulargui.elements.GuiWindow;
 
@@ -13,25 +14,48 @@ public class ChatWindowManager {
     private static final int SNAP_DISTANCE = 10;
     
     private final List<GuiWindow> managedWindows = new ArrayList<>();
+    private ChatLayoutManager layoutManager;
 
     public ChatWindowManager() {
+    }
+
+    public ChatWindowManager(ChatLayoutManager layoutManager) {
+        this.layoutManager = layoutManager;
+    }
+
+    public void setLayoutManager(ChatLayoutManager layoutManager) {
+        this.layoutManager = layoutManager;
     }
 
     public void addWindow(GuiWindow window) {
         managedWindows.add(window);
         
-        // Add hooking for move completion to do snapping
-        window.setOnMovedCallback(() -> handleWindowMoved(window));
+        if (window instanceof FloatingChatWindow fcw) {
+            fcw.setWindowManager(this);
+            window.setOnMovedCallback(() -> {
+                handleWindowMoved(window);
+                autoSave(fcw);
+            });
+            window.setOnResizedCallback(() -> autoSave(fcw));
+        } else {
+            window.setOnMovedCallback(() -> handleWindowMoved(window));
+        }
     }
 
     public void removeWindow(GuiWindow window) {
         managedWindows.remove(window);
+        window.setEnabled(false);
     }
 
     public void bringToFront(GuiWindow window) {
         if (managedWindows.remove(window)) {
             managedWindows.add(window);
         }
+    }
+
+    /** Returns true if this window is the topmost managed window. */
+    public boolean isFrontWindow(GuiWindow window) {
+        return !managedWindows.isEmpty() && managedWindows.get(managedWindows.size() - 1) == window;
     }
 
     private void handleWindowMoved(GuiWindow movedWindow) {
@@ -49,6 +73,15 @@ public class ChatWindowManager {
             }
             
             // Further snapping logic can be expanded here
+        }
+    }
+
+    private void autoSave(FloatingChatWindow fcw) {
+        if (layoutManager != null) {
+            String id = fcw.getChannel().getChannelId().toString();
+            ChatWindowLayout layout = layoutManager.getOrCreateLayout(id);
+            fcw.saveToLayout(layout);
+            layoutManager.save();
         }
     }
 }

--- a/common/src/main/java/net/creeperhost/polylib/chat/client/FloatingChatWindow.java
+++ b/common/src/main/java/net/creeperhost/polylib/chat/client/FloatingChatWindow.java
@@ -3,6 +3,15 @@ package net.creeperhost.polylib.chat.client;
 import net.creeperhost.polylib.chat.ChatChannel;
 import net.creeperhost.polylib.chat.ChatMember;
 import net.creeperhost.polylib.chat.RichChatMessage;
+import net.creeperhost.polylib.chat.client.PulseEffect;
+import net.creeperhost.polylib.chat.client.ChatNotifications;
+import net.creeperhost.polylib.chat.layout.ChatWindowLayout;
+import net.creeperhost.polylib.chat.layout.SnapCorner;
+import net.creeperhost.polylib.chat.client.tab.ChatTabInjection;
+import net.creeperhost.polylib.chat.client.tab.ChatTabRegistry;
+import net.creeperhost.polylib.chat.client.tab.ChatTabBarSide;
+import net.creeperhost.polylib.chat.client.tab.ChatTabBarTop;
+import net.creeperhost.polylib.chat.client.tab.TabPosition;
 import net.creeperhost.polylib.client.modulargui.elements.GuiButton;
 import net.creeperhost.polylib.client.modulargui.elements.GuiRectangle;
 import net.creeperhost.polylib.client.modulargui.elements.GuiScrolling;
@@ -10,16 +19,38 @@ import net.creeperhost.polylib.client.modulargui.elements.GuiText;
 import net.creeperhost.polylib.client.modulargui.elements.GuiTextField;
 import net.creeperhost.polylib.client.modulargui.elements.GuiTexture;
 import net.creeperhost.polylib.client.modulargui.elements.GuiWindow;
+import net.creeperhost.polylib.client.modulargui.lib.Constraints;
 import net.creeperhost.polylib.client.modulargui.lib.geometry.Constraint;
+import net.creeperhost.polylib.client.modulargui.lib.geometry.Rectangle;
 import net.creeperhost.polylib.client.modulargui.sprite.Material;
 import net.creeperhost.polylib.client.modulargui.lib.geometry.GeoParam;
 import net.creeperhost.polylib.client.modulargui.lib.geometry.GuiParent;
 import net.creeperhost.polylib.client.modulargui.elements.GuiElement;
+import net.creeperhost.polylib.client.modulargui.lib.ForegroundRender;
+import net.creeperhost.polylib.client.modulargui.lib.GuiRender;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.Font;
+import net.minecraft.network.chat.Component;
 
 /**
  * The actual chat UI that renders a ChatChannel.
  */
-public class FloatingChatWindow extends GuiWindow {
+public class FloatingChatWindow extends GuiWindow implements ForegroundRender {
+
+    private static final int CORNER_SNAP_THRESHOLD = 40;
+    private static final int DOCK_THRESHOLD = 10;
+
+    /**
+     * Persists minimized state across chat close/reopen (keyed by channel ID path).
+     * Cleared when a window is permanently closed (docked or X'd).
+     */
+    private static final java.util.Map<String, Boolean> MINIMIZED_STATE = new java.util.HashMap<>();
+
+    /**
+     * Persists window position (xMin, yMin, width, height) across chat close/reopen.
+     * Cleared when a window is permanently closed.
+     */
+    public static final java.util.Map<String, double[]> SAVED_POSITIONS = new java.util.HashMap<>();
 
     private final ChatChannel channel;
     
@@ -27,11 +58,69 @@ public class FloatingChatWindow extends GuiWindow {
     private final GuiScrolling messageArea;
     private final GuiTextField inputField;
 
+    // Plan B: window manager reference, minimize, snap
+    private ChatWindowManager windowManager;
+    private final GuiButton minimizeButton;
+    private boolean minimized = false;
+    private double restoreHeight = 150;
+    private SnapCorner currentSnapCorner = null;
+    private TabPosition sourceTabPosition = TabPosition.TOP;
+    private DockTarget pendingDockTarget = null;
+
+    // Plan C: mention pulse
+    private final PulseEffect pulseEffect = new PulseEffect();
+    private boolean isPulsing = false;
+    private static final int NORMAL_HEADER_COLOR = 0xFF333333;
+    private ChatNotifications.PulseListener pulseListener;
+
+    /** Set while any floating window is being dragged; used to show empty side bars as drop targets. */
+    public static boolean anyWindowDragging = false;
+
     public FloatingChatWindow(GuiParent<?> parent, ChatChannel channel) {
         super(parent);
         this.channel = channel;
         
         setTitle(channel.getName());
+
+        // Wire close button — re-docks to original tab position
+        getCloseButton().setOpaque(true);
+        getCloseButton().onClick(() -> {
+            ChatTabRegistry registry = ChatTabRegistry.get();
+            registry.unmarkFloating(channel.getChannelId());
+            switch (sourceTabPosition) {
+                case TOP -> registry.registerTop(channel);
+                case SIDE_LEFT -> registry.registerSideLeft(channel);
+                case SIDE_RIGHT -> registry.registerSideRight(channel);
+            }
+            dispose();
+            if (windowManager != null) {
+                windowManager.removeWindow(this);
+            }
+        });
+
+        // Add background fill to close button so it's visible (brightens on hover)
+        GuiRectangle closeBg = new GuiRectangle(getCloseButton());
+        Constraints.bind(closeBg, getCloseButton());
+        closeBg.fill(() -> getCloseButton().isMouseOver() ? 0xFFCC4444 : 0xFF993333);
+
+        // Minimize button — left of close button
+        this.minimizeButton = new GuiButton(getHeaderBar());
+        this.minimizeButton.setOpaque(true);
+        this.minimizeButton.constrain(GeoParam.RIGHT, Constraint.relative(getCloseButton().get(GeoParam.LEFT), -2))
+                           .constrain(GeoParam.TOP, Constraint.relative(getHeaderBar().get(GeoParam.TOP), 2))
+                           .constrain(GeoParam.WIDTH, Constraint.literal(10))
+                           .constrain(GeoParam.HEIGHT, Constraint.literal(10));
+        // Add background fill to minimize button (brightens on hover)
+        GuiRectangle minBg = new GuiRectangle(this.minimizeButton);
+        Constraints.bind(minBg, this.minimizeButton);
+        minBg.fill(() -> this.minimizeButton.isMouseOver() ? 0xFF777777 : 0xFF555555);
+        GuiText minLabel = new GuiText(this.minimizeButton, Component.literal("_"));
+        minLabel.constrain(GeoParam.LEFT, Constraint.match(this.minimizeButton.get(GeoParam.LEFT)))
+                .constrain(GeoParam.TOP, Constraint.match(this.minimizeButton.get(GeoParam.TOP)))
+                .constrain(GeoParam.RIGHT, Constraint.match(this.minimizeButton.get(GeoParam.RIGHT)))
+                .constrain(GeoParam.BOTTOM, Constraint.match(this.minimizeButton.get(GeoParam.BOTTOM)));
+        this.minimizeButton.setLabel(minLabel);
+        this.minimizeButton.onClick(this::toggleMinimize);
 
         // Setup Sidebar
         this.sidebar = new GuiRectangle(getBackground());
@@ -69,11 +158,335 @@ public class FloatingChatWindow extends GuiWindow {
 
         // Hook up listeners
         this.channel.addMessageListener(this::onNewMessage);
-        
+
+        // Plan C: register pulse observer — observe ChatNotifications state changes
+        this.pulseListener = (channelId, pulsing) -> {
+            if (!channelId.equals(channel.getChannelId())) return;
+            // If we're already the focused front window, dismiss the pulse immediately
+            if (pulsing && isFocusedWindow()) {
+                ChatNotifications.clearPulse(channelId);
+                return;
+            }
+            isPulsing = pulsing;
+            if (pulsing) {
+                pulseEffect.reset();
+                getHeaderBar().fill(() -> pulseEffect.getColor());
+            } else {
+                getHeaderBar().fill(NORMAL_HEADER_COLOR);
+            }
+        };
+        ChatNotifications.addPulseListener(pulseListener);
+
         // Initial render
         refreshMembers();
         refreshMessages();
     }
+
+    // --- Accessors ---
+
+    public ChatChannel getChannel() { return channel; }
+
+    public FloatingChatWindow setWindowManager(ChatWindowManager manager) {
+        this.windowManager = manager;
+        return this;
+    }
+
+    public boolean isMinimized() { return minimized; }
+
+    /** Called after constraints are set to restore minimized state from previous session. */
+    public void applyRestoredState() {
+        if (Boolean.TRUE.equals(MINIMIZED_STATE.get(channel.getChannelId().toString())) && !minimized) {
+            toggleMinimize();
+        }
+    }
+
+    public SnapCorner getCurrentSnapCorner() { return currentSnapCorner; }
+
+    public FloatingChatWindow setSourceTabPosition(TabPosition pos) {
+        this.sourceTabPosition = pos;
+        return this;
+    }
+
+    public TabPosition getSourceTabPosition() { return sourceTabPosition; }
+
+    // --- Dock zone visual overlay (ForegroundRender) ---
+
+    @Override
+    public void renderInFront(GuiRender render, double mouseX, double mouseY, float partialTicks) {
+        if (!isDraggingPosition()) return;
+
+        int sw = scaledScreenWidth();
+        int sh = scaledScreenHeight();
+
+        // Zone bounds: TOP strip at bottom, side strips on edges
+        double topZoneY = sh - 28;   // where the top-bar sits (bottom=sh-14, height=14)
+        double topZoneH = 14;
+        double sideZoneTop = 0;
+        double sideZoneBottom = topZoneY;
+        double sideZoneH = sideZoneBottom - sideZoneTop;
+        double leftZoneW = 16;
+        double rightZoneX = sw - 18;
+        double rightZoneW = 16;
+
+        int dimColor    = 0x2200FFFF;  // very translucent cyan hint
+        int activeColor = 0x8844FFAA;  // semi-opaque green highlight
+
+        // Draw TOP zone
+        render.rect(0, topZoneY, sw, topZoneH,
+            pendingDockTarget == DockTarget.TOP ? activeColor : dimColor);
+
+        // Draw SIDE_LEFT zone
+        render.rect(0, sideZoneTop, leftZoneW, sideZoneH,
+            pendingDockTarget == DockTarget.SIDE_LEFT ? activeColor : dimColor);
+
+        // Draw SIDE_RIGHT zone
+        render.rect(rightZoneX, sideZoneTop, rightZoneW, sideZoneH,
+            pendingDockTarget == DockTarget.SIDE_RIGHT ? activeColor : dimColor);
+    }
+
+    // --- Cursor fix + pulse tick ---
+
+    @Override
+    public void tick(double mouseX, double mouseY) {
+        super.tick(mouseX, mouseY);
+        if (getCloseButton().isMouseOver() || minimizeButton.isMouseOver()) {
+            getModularGui().setCursor(null);
+        }
+        if (isPulsing) {
+            pulseEffect.tick();
+        }
+    }
+
+    @Override
+    public boolean mouseClicked(double mouseX, double mouseY, int button) {
+        boolean result = super.mouseClicked(mouseX, mouseY, button);
+        // Clear pulse when user clicks this window
+        ChatNotifications.clearPulse(channel.getChannelId());
+        return result;
+    }
+
+    /**
+     * Call when permanently closing this window (not just docking) to release listeners.
+     */
+    public void dispose() {
+        MINIMIZED_STATE.remove(channel.getChannelId().toString());
+        SAVED_POSITIONS.remove(channel.getChannelId().toString());
+        ChatNotifications.removePulseListener(pulseListener);
+        channel.removeMessageListener(this::onNewMessage);
+    }
+
+    // --- Minimize ---
+
+    /** Height of the header bar (title + buttons); must match GuiWindow's headerBar HEIGHT constraint. */
+    private static final int HEADER_HEIGHT = 14;
+
+    private void toggleMinimize() {
+        minimized = !minimized;
+        MINIMIZED_STATE.put(channel.getChannelId().toString(), minimized);
+        if (minimized) {
+            restoreHeight = yMax - yMin; // raw fields — reliable here since not mid-constraint-solve
+            sidebar.setEnabled(false);
+            messageArea.setEnabled(false);
+            if (inputField != null) inputField.setEnabled(false);
+            // Write the raw field that drives contentElement, AND update the outer HEIGHT constraint
+            // so that resetBounds() (called on onScreenInit) also reads back the correct value.
+            yMax = yMin + HEADER_HEIGHT;
+            super.constrain(GeoParam.HEIGHT, Constraint.literal(HEADER_HEIGHT)); // bypass resetBounds override
+            setMinSize(Rectangle.create(0, 0, 50, HEADER_HEIGHT));
+        } else {
+            sidebar.setEnabled(true);
+            messageArea.setEnabled(true);
+            if (inputField != null) inputField.setEnabled(true);
+            yMax = yMin + restoreHeight;
+            super.constrain(GeoParam.HEIGHT, Constraint.literal(restoreHeight));
+            setMinSize(Rectangle.create(0, 0, 50, 50));
+        }
+        ((GuiText) minimizeButton.getLabel()).setText(
+            Component.literal(minimized ? "\u25A1" : "_")
+        );
+    }
+
+    // --- Corner Snap ---
+
+    @Override
+    protected void onFinishMove(double mouseX, double mouseY) {
+        super.onFinishMove(mouseX, mouseY);
+        anyWindowDragging = false;
+        pendingDockTarget = null;
+
+        // Check for dock targets first (dock takes priority over corner snap)
+        DockTarget target = detectDockTarget(mouseX, mouseY);
+        if (target != null) {
+            dockToTabBar(target);
+            return;
+        }
+
+        // Corner snap detection
+        double centerX = (xMin + xMax) / 2.0;
+        double centerY = (yMin + yMax) / 2.0;
+        int sw = scaledScreenWidth();
+        int sh = scaledScreenHeight();
+
+        SnapCorner corner = SnapCorner.detect(centerX, centerY, sw, sh, CORNER_SNAP_THRESHOLD);
+        if (corner != null) {
+            snapToCorner(corner);
+        } else {
+            currentSnapCorner = null;
+        }
+        savePosition(); // save after snap is applied
+    }
+
+    @Override
+    protected void onManipulated(double mouseX, double mouseY) {
+        super.onManipulated(mouseX, mouseY);
+        anyWindowDragging = true;
+        pendingDockTarget = detectDockTarget(mouseX, mouseY);
+        savePosition(); // capture resize updates
+    }
+
+    private void savePosition() {
+        SAVED_POSITIONS.put(channel.getChannelId().toString(),
+            new double[]{xMin, yMin, xMax - xMin, minimized ? restoreHeight : yMax - yMin});
+    }
+
+    private void snapToCorner(SnapCorner corner) {
+        currentSnapCorner = corner;
+        int w = (int)(xMax - xMin);
+        int h = (int)(yMax - yMin);
+        int sw = scaledScreenWidth();
+        int sh = scaledScreenHeight();
+        int[] pos = corner.computePosition(w, h, sw, sh);
+        xMin = pos[0];
+        yMin = pos[1];
+        xMax = xMin + w;
+        yMax = yMin + h;
+    }
+
+    // --- Screen Resize Re-anchor ---
+
+    @Override
+    public void onScreenInit(Minecraft mc, Font font, int screenWidth, int screenHeight) {
+        super.onScreenInit(mc, font, screenWidth, screenHeight);
+        // Re-anchor corner-snapped windows after screen resize
+        if (currentSnapCorner != null) {
+            snapToCorner(currentSnapCorner);
+        }
+        // Restore minimized state now that constraints are fully resolved and yMin/yMax are valid
+        boolean shouldBeMinimized = Boolean.TRUE.equals(MINIMIZED_STATE.get(channel.getChannelId().toString()));
+        if (shouldBeMinimized && !minimized) {
+            toggleMinimize();
+        }
+    }
+
+    // --- Drag-to-Dock ---
+
+    private enum DockTarget { TOP, SIDE_LEFT, SIDE_RIGHT }
+
+    private DockTarget detectDockTarget(double mouseX, double mouseY) {
+        // Check against actual tab bar elements
+        ChatTabBarTop topBar = ChatTabInjection.getTopBar();
+        ChatTabBarSide leftBar = ChatTabInjection.getSideBarLeft();
+        ChatTabBarSide rightBar = ChatTabInjection.getSideBarRight();
+
+        // Near top bar
+        if (topBar != null) {
+            double barTop = topBar.yMin();
+            double barBottom = topBar.yMax();
+            if (this.yMax > barTop - DOCK_THRESHOLD && this.yMax < barBottom + DOCK_THRESHOLD
+                    && this.xMax >= topBar.xMin() && this.xMin <= topBar.xMax()) {
+                return DockTarget.TOP;
+            }
+        }
+
+        // Near left sidebar
+        if (leftBar != null) {
+            double lxMin = leftBar.xMin();
+            double lxMax = leftBar.xMax();
+            double lyMin = leftBar.yMin();
+            double lyMax = leftBar.yMax();
+            if (this.xMin >= lxMin - DOCK_THRESHOLD && this.xMin <= lxMax + DOCK_THRESHOLD
+                    && this.yMax >= lyMin && this.yMin <= lyMax) {
+                return DockTarget.SIDE_LEFT;
+            }
+        }
+
+        // Near right sidebar
+        if (rightBar != null) {
+            double rxMin = rightBar.xMin();
+            double rxMax = rightBar.xMax();
+            double ryMin = rightBar.yMin();
+            double ryMax = rightBar.yMax();
+            if (this.xMax >= rxMin - DOCK_THRESHOLD && this.xMax <= rxMax + DOCK_THRESHOLD
+                    && this.yMax >= ryMin && this.yMin <= ryMax) {
+                return DockTarget.SIDE_RIGHT;
+            }
+        }
+
+        // Fallback screen-edge detection (when bars don't exist)
+        int sw = scaledScreenWidth();
+        int sh = scaledScreenHeight();
+        // Near bottom of screen → TOP
+        if (this.yMax > sh - 14 - DOCK_THRESHOLD) {
+            return DockTarget.TOP;
+        }
+        // Near left edge → SIDE_LEFT
+        if (this.xMin < 20) {
+            return DockTarget.SIDE_LEFT;
+        }
+        // Near right edge → SIDE_RIGHT
+        if (this.xMax > sw - 20) {
+            return DockTarget.SIDE_RIGHT;
+        }
+        return null;
+    }
+
+    private void dockToTabBar(DockTarget target) {
+        ChatTabRegistry registry = ChatTabRegistry.get();
+        registry.unmarkFloating(channel.getChannelId());
+        switch (target) {
+            case TOP -> registry.registerTop(channel);
+            case SIDE_LEFT -> registry.registerSideLeft(channel);
+            case SIDE_RIGHT -> registry.registerSideRight(channel);
+        }
+        dispose();
+        if (windowManager != null) {
+            windowManager.removeWindow(this);
+        }
+    }
+
+    private boolean isFocusedWindow() {
+        if (inputField != null && inputField.isFocused()) return true;
+        return windowManager != null && windowManager.isFrontWindow(this);
+    }
+
+    // --- Persistence ---
+
+    public void saveToLayout(ChatWindowLayout layout) {
+        layout.setX((int) xMin);
+        layout.setY((int) yMin);
+        layout.setWidth((int)(xMax - xMin));
+        layout.setHeight((int)(yMax - yMin));
+        layout.setMinimized(minimized);
+        layout.setSnapCorner(currentSnapCorner);
+        layout.setDisplayMode(ChatWindowLayout.DisplayMode.FLOATING);
+    }
+
+    public void loadFromLayout(ChatWindowLayout layout) {
+        xMin = layout.getX();
+        yMin = layout.getY();
+        xMax = xMin + layout.getWidth();
+        yMax = yMin + layout.getHeight();
+        restoreHeight = layout.getHeight();
+
+        if (layout.getSnapCorner() != null) {
+            snapToCorner(layout.getSnapCorner());
+        }
+        if (layout.isMinimized() && !minimized) {
+            toggleMinimize();
+        }
+    }
+
+    // --- Message/Member Rendering ---
 
     private void onNewMessage(RichChatMessage message) {
         refreshMessages();
@@ -83,7 +496,7 @@ public class FloatingChatWindow extends GuiWindow {
         new java.util.ArrayList<>(sidebar.getChildren()).forEach(sidebar::removeChild);
         
         GuiText headerText = new GuiText(sidebar);
-        headerText.setText(net.minecraft.network.chat.Component.literal("Members"));
+        headerText.setText(Component.literal("Members"));
         headerText.constrain(GeoParam.LEFT, Constraint.relative(sidebar.get(GeoParam.LEFT), 2))
                 .constrain(GeoParam.TOP, Constraint.relative(sidebar.get(GeoParam.TOP), 2));
         
@@ -104,7 +517,6 @@ public class FloatingChatWindow extends GuiWindow {
     private void refreshMessages() {
         new java.util.ArrayList<>(messageArea.getContentElement().getChildren()).forEach(messageArea.getContentElement()::removeChild);
         
-        // Prevent horizontal scroll by constraining width
         messageArea.getContentElement().constrain(GeoParam.WIDTH, Constraint.match(messageArea.get(GeoParam.WIDTH)));
         
         GuiElement<?> lastElement = null;
@@ -131,7 +543,7 @@ public class FloatingChatWindow extends GuiWindow {
             }
 
             GuiText msgText = new GuiText(container);
-            msgText.setText(net.minecraft.network.chat.Component.literal("<")
+            msgText.setText(Component.literal("<")
                 .append(msg.senderName())
                 .append("> ")
                 .append(msg.content()));

--- a/common/src/main/java/net/creeperhost/polylib/chat/client/FloatingChatWindow.java
+++ b/common/src/main/java/net/creeperhost/polylib/chat/client/FloatingChatWindow.java
@@ -1,0 +1,149 @@
+package net.creeperhost.polylib.chat.client;
+
+import net.creeperhost.polylib.chat.ChatChannel;
+import net.creeperhost.polylib.chat.ChatMember;
+import net.creeperhost.polylib.chat.RichChatMessage;
+import net.creeperhost.polylib.client.modulargui.elements.GuiButton;
+import net.creeperhost.polylib.client.modulargui.elements.GuiRectangle;
+import net.creeperhost.polylib.client.modulargui.elements.GuiScrolling;
+import net.creeperhost.polylib.client.modulargui.elements.GuiText;
+import net.creeperhost.polylib.client.modulargui.elements.GuiTextField;
+import net.creeperhost.polylib.client.modulargui.elements.GuiTexture;
+import net.creeperhost.polylib.client.modulargui.elements.GuiWindow;
+import net.creeperhost.polylib.client.modulargui.lib.geometry.Constraint;
+import net.creeperhost.polylib.client.modulargui.sprite.Material;
+import net.creeperhost.polylib.client.modulargui.lib.geometry.GeoParam;
+import net.creeperhost.polylib.client.modulargui.lib.geometry.GuiParent;
+import net.creeperhost.polylib.client.modulargui.elements.GuiElement;
+
+/**
+ * The actual chat UI that renders a ChatChannel.
+ */
+public class FloatingChatWindow extends GuiWindow {
+
+    private final ChatChannel channel;
+    
+    private final GuiRectangle sidebar;
+    private final GuiScrolling messageArea;
+    private final GuiTextField inputField;
+
+    public FloatingChatWindow(GuiParent<?> parent, ChatChannel channel) {
+        super(parent);
+        this.channel = channel;
+        
+        setTitle(channel.getName());
+
+        // Setup Sidebar
+        this.sidebar = new GuiRectangle(getBackground());
+        this.sidebar.constrain(GeoParam.RIGHT, Constraint.match(getBackground().get(GeoParam.RIGHT)))
+                    .constrain(GeoParam.TOP, Constraint.match(getHeaderBar().get(GeoParam.BOTTOM)))
+                    .constrain(GeoParam.BOTTOM, Constraint.match(getBackground().get(GeoParam.BOTTOM)))
+                    .constrain(GeoParam.WIDTH, Constraint.literal(50))
+                    .fill(0x55000000);
+
+        // Setup Message Area
+        this.messageArea = new GuiScrolling(getBackground());
+        this.messageArea.constrain(GeoParam.LEFT, Constraint.match(getBackground().get(GeoParam.LEFT)))
+                        .constrain(GeoParam.RIGHT, Constraint.match(sidebar.get(GeoParam.LEFT)))
+                        .constrain(GeoParam.TOP, Constraint.match(getHeaderBar().get(GeoParam.BOTTOM)))
+                        .constrain(GeoParam.BOTTOM, Constraint.relative(getBackground().get(GeoParam.BOTTOM), channel.canReply() ? -20 : 0));
+
+        // Setup Input Field (only if channel supports replies)
+        if (channel.canReply()) {
+            this.inputField = new GuiTextField(getBackground());
+            this.inputField.constrain(GeoParam.LEFT, Constraint.match(getBackground().get(GeoParam.LEFT)))
+                           .constrain(GeoParam.RIGHT, Constraint.match(getBackground().get(GeoParam.RIGHT)))
+                           .constrain(GeoParam.BOTTOM, Constraint.match(getBackground().get(GeoParam.BOTTOM)))
+                           .constrain(GeoParam.HEIGHT, Constraint.literal(20));
+                           
+            this.inputField.setEnterPressed(() -> {
+                String text = this.inputField.getValue();
+                if (!text.isEmpty()) {
+                    this.channel.submitMessage(text);
+                    this.inputField.setValue("");
+                }
+            });
+        } else {
+            this.inputField = null;
+        }
+
+        // Hook up listeners
+        this.channel.addMessageListener(this::onNewMessage);
+        
+        // Initial render
+        refreshMembers();
+        refreshMessages();
+    }
+
+    private void onNewMessage(RichChatMessage message) {
+        refreshMessages();
+    }
+
+    private void refreshMembers() {
+        new java.util.ArrayList<>(sidebar.getChildren()).forEach(sidebar::removeChild);
+        
+        GuiText headerText = new GuiText(sidebar);
+        headerText.setText(net.minecraft.network.chat.Component.literal("Members"));
+        headerText.constrain(GeoParam.LEFT, Constraint.relative(sidebar.get(GeoParam.LEFT), 2))
+                .constrain(GeoParam.TOP, Constraint.relative(sidebar.get(GeoParam.TOP), 2));
+        
+        GuiElement<?> lastElement = headerText;
+        
+        for (ChatMember member : channel.getMembers()) {
+            GuiText nameText = new GuiText(sidebar);
+            nameText.setText(member.displayName());
+            nameText.constrain(GeoParam.LEFT, Constraint.relative(sidebar.get(GeoParam.LEFT), 2))
+                    .constrain(GeoParam.TOP, Constraint.relative(lastElement.get(GeoParam.BOTTOM), 2))
+                    .constrain(GeoParam.RIGHT, Constraint.relative(sidebar.get(GeoParam.RIGHT), -2))
+                    .setWrap(true).setAlignment(net.creeperhost.polylib.client.modulargui.lib.geometry.Align.MIN).autoHeight();
+            
+            lastElement = nameText;
+        }
+    }
+
+    private void refreshMessages() {
+        new java.util.ArrayList<>(messageArea.getContentElement().getChildren()).forEach(messageArea.getContentElement()::removeChild);
+        
+        // Prevent horizontal scroll by constraining width
+        messageArea.getContentElement().constrain(GeoParam.WIDTH, Constraint.match(messageArea.get(GeoParam.WIDTH)));
+        
+        GuiElement<?> lastElement = null;
+        for (RichChatMessage msg : channel.getMessages()) {
+            GuiElement<?> container = new GuiElement<>(messageArea.getContentElement());
+            container.constrain(GeoParam.LEFT, Constraint.match(messageArea.getContentElement().get(GeoParam.LEFT)));
+            container.constrain(GeoParam.RIGHT, Constraint.match(messageArea.getContentElement().get(GeoParam.RIGHT)));
+            
+            if (lastElement == null) {
+                container.constrain(GeoParam.TOP, Constraint.match(messageArea.getContentElement().get(GeoParam.TOP)));
+            } else {
+                container.constrain(GeoParam.TOP, Constraint.match(lastElement.get(GeoParam.BOTTOM)));
+            }
+
+            double currentX = 2;
+            
+            if (msg.senderIcon() != null) {
+                GuiTexture icon = new GuiTexture(container, Material.fromRawTexture(msg.senderIcon()));
+                icon.constrain(GeoParam.LEFT, Constraint.relative(container.get(GeoParam.LEFT), currentX))
+                    .constrain(GeoParam.TOP, Constraint.relative(container.get(GeoParam.TOP), 2))
+                    .constrain(GeoParam.WIDTH, Constraint.literal(8))
+                    .constrain(GeoParam.HEIGHT, Constraint.literal(8));
+                currentX += 10;
+            }
+
+            GuiText msgText = new GuiText(container);
+            msgText.setText(net.minecraft.network.chat.Component.literal("<")
+                .append(msg.senderName())
+                .append("> ")
+                .append(msg.content()));
+                
+            msgText.constrain(GeoParam.LEFT, Constraint.relative(container.get(GeoParam.LEFT), currentX))
+                   .constrain(GeoParam.TOP, Constraint.match(container.get(GeoParam.TOP)))
+                   .constrain(GeoParam.RIGHT, Constraint.relative(container.get(GeoParam.RIGHT), -2))
+                   .setWrap(true).setAlignment(net.creeperhost.polylib.client.modulargui.lib.geometry.Align.MIN).autoHeight();
+            
+            container.constrain(GeoParam.HEIGHT, Constraint.relative(msgText.get(GeoParam.HEIGHT), 2));
+            
+            lastElement = container;
+        }
+    }
+}

--- a/common/src/main/java/net/creeperhost/polylib/chat/client/PulseEffect.java
+++ b/common/src/main/java/net/creeperhost/polylib/chat/client/PulseEffect.java
@@ -1,0 +1,46 @@
+package net.creeperhost.polylib.chat.client;
+
+/**
+ * Generates a pulsing ARGB color that cycles between two colors over time.
+ * Used for mention pulse on floating window headers and tab badges.
+ */
+public class PulseEffect {
+
+    private static final int COLOR_A = 0xFFFFAA00; // yellow-orange
+    private static final int COLOR_B = 0xFFFF6600; // deep orange
+    private static final int CYCLE_TICKS = 20;     // full cycle = 1 second
+
+    private int tickCounter = 0;
+
+    /** Call once per client tick while the pulse is active. */
+    public void tick() {
+        tickCounter++;
+    }
+
+    /** Reset the animation (e.g. when pulse starts). */
+    public void reset() {
+        tickCounter = 0;
+    }
+
+    /** Get the current interpolated ARGB color. */
+    public int getColor() {
+        return colorForTick(tickCounter);
+    }
+
+    /** Static convenience: get pulse color for a given tick count. */
+    public static int colorForTick(int tick) {
+        double phase = (tick % CYCLE_TICKS) / (double) CYCLE_TICKS;
+        double t = phase < 0.5 ? phase * 2.0 : 2.0 - phase * 2.0;
+        return lerpColor(COLOR_A, COLOR_B, t);
+    }
+
+    private static int lerpColor(int c1, int c2, double t) {
+        int a1 = (c1 >> 24) & 0xFF, r1 = (c1 >> 16) & 0xFF, g1 = (c1 >> 8) & 0xFF, b1 = c1 & 0xFF;
+        int a2 = (c2 >> 24) & 0xFF, r2 = (c2 >> 16) & 0xFF, g2 = (c2 >> 8) & 0xFF, b2 = c2 & 0xFF;
+        int a = (int)(a1 + (a2 - a1) * t);
+        int r = (int)(r1 + (r2 - r1) * t);
+        int g = (int)(g1 + (g2 - g1) * t);
+        int b = (int)(b1 + (b2 - b1) * t);
+        return (a << 24) | (r << 16) | (g << 8) | b;
+    }
+}

--- a/common/src/main/java/net/creeperhost/polylib/chat/client/VanillaChatResize.java
+++ b/common/src/main/java/net/creeperhost/polylib/chat/client/VanillaChatResize.java
@@ -1,0 +1,57 @@
+package net.creeperhost.polylib.chat.client;
+
+import net.creeperhost.polylib.chat.layout.ChatLayoutManager;
+
+/**
+ * Opt-in API for making the vanilla chat area resizable.
+ * PolyLib does NOT register this by default. Mods call {@link #enable()} to opt in.
+ *
+ * When enabled, the vanilla chat history region gains drag handles on its top and right
+ * edges, allowing the player to resize the chat area. The resized dimensions are persisted
+ * in ChatLayoutManager under a special layout ID.
+ */
+public class VanillaChatResize {
+
+    public static final String LAYOUT_ID = "polylib:vanilla_chat";
+
+    private static boolean enabled = false;
+    private static int customWidth = -1;  // -1 = use vanilla default
+    private static int customHeight = -1; // -1 = use vanilla default
+
+    /**
+     * Enable resizable vanilla chat. Call during client init.
+     */
+    public static void enable() {
+        enabled = true;
+    }
+
+    /**
+     * Disable resizable vanilla chat. Reverts to vanilla dimensions.
+     */
+    public static void disable() {
+        enabled = false;
+    }
+
+    public static boolean isEnabled() {
+        return enabled;
+    }
+
+    public static int getCustomWidth() { return customWidth; }
+    public static void setCustomWidth(int width) { customWidth = width; }
+
+    public static int getCustomHeight() { return customHeight; }
+    public static void setCustomHeight(int height) { customHeight = height; }
+
+    public static void save(ChatLayoutManager manager) {
+        var layout = manager.getOrCreateLayout(LAYOUT_ID);
+        layout.setWidth(customWidth);
+        layout.setHeight(customHeight);
+        manager.save();
+    }
+
+    public static void load(ChatLayoutManager manager) {
+        var layout = manager.getOrCreateLayout(LAYOUT_ID);
+        if (layout.getWidth() > 0) customWidth = layout.getWidth();
+        if (layout.getHeight() > 0) customHeight = layout.getHeight();
+    }
+}

--- a/common/src/main/java/net/creeperhost/polylib/chat/client/notification/FloatingNotificationWindow.java
+++ b/common/src/main/java/net/creeperhost/polylib/chat/client/notification/FloatingNotificationWindow.java
@@ -1,0 +1,224 @@
+package net.creeperhost.polylib.chat.client.notification;
+
+import net.creeperhost.polylib.chat.client.ChatWindowManager;
+import net.creeperhost.polylib.chat.client.PulseEffect;
+import net.creeperhost.polylib.client.modulargui.elements.GuiButton;
+import net.creeperhost.polylib.client.modulargui.elements.GuiElement;
+import net.creeperhost.polylib.client.modulargui.elements.GuiRectangle;
+import net.creeperhost.polylib.client.modulargui.elements.GuiScrolling;
+import net.creeperhost.polylib.client.modulargui.elements.GuiText;
+import net.creeperhost.polylib.client.modulargui.elements.GuiWindow;
+import net.creeperhost.polylib.client.modulargui.lib.geometry.Align;
+import net.creeperhost.polylib.client.modulargui.lib.geometry.Constraint;
+import net.creeperhost.polylib.client.modulargui.lib.geometry.GeoParam;
+import net.creeperhost.polylib.client.modulargui.lib.geometry.GuiParent;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.Identifier;
+
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * Floating notification window — read-only scrollable list of NotificationEntry items.
+ * ALERT entries pulse the header yellow→orange. Inherits drag/minimize/resize from GuiWindow.
+ */
+public class FloatingNotificationWindow extends GuiWindow {
+
+    private static final int NORMAL_HEADER_COLOR = 0xFF333333;
+
+    private final Identifier windowId;
+    private final GuiScrolling entryList;
+    private final GuiText badgeText;
+    private final PulseEffect pulseEffect = new PulseEffect();
+    private boolean isPulsing = false;
+    private ChatWindowManager windowManager;
+
+    private final NotificationWindowRegistry.NotificationListener listener;
+
+    public FloatingNotificationWindow(GuiParent<?> parent, Identifier windowId) {
+        super(parent);
+        this.windowId = windowId;
+
+        NotificationWindowRegistry.WindowState state = NotificationWindowRegistry.getWindowState(windowId);
+        setTitle(state != null ? state.getTitle() : Component.literal("Notifications"));
+
+        // Unread badge in header, right of title
+        this.badgeText = new GuiText(getHeaderBar());
+        this.badgeText.constrain(GeoParam.RIGHT, Constraint.relative(getCloseButton().get(GeoParam.LEFT), -4))
+                      .constrain(GeoParam.TOP, Constraint.relative(getHeaderBar().get(GeoParam.TOP), 2))
+                      .setShadow(true);
+
+        // Clear-all button in header, left of badge
+        GuiButton clearAllButton = new GuiButton(getHeaderBar());
+        clearAllButton.setOpaque(true);
+        clearAllButton.constrain(GeoParam.RIGHT, Constraint.relative(badgeText.get(GeoParam.LEFT), -2))
+                      .constrain(GeoParam.TOP, Constraint.relative(getHeaderBar().get(GeoParam.TOP), 2))
+                      .constrain(GeoParam.WIDTH, Constraint.literal(14))
+                      .constrain(GeoParam.HEIGHT, Constraint.literal(10));
+        GuiRectangle clearBg = new GuiRectangle(clearAllButton);
+        net.creeperhost.polylib.client.modulargui.lib.Constraints.bind(clearBg, clearAllButton);
+        clearBg.fill(() -> clearAllButton.isMouseOver() ? 0xFF666666 : 0xFF444444);
+        GuiText clearLabel = new GuiText(clearAllButton, Component.literal("clr"));
+        clearLabel.constrain(GeoParam.LEFT, Constraint.relative(clearAllButton.get(GeoParam.LEFT), 1))
+                  .constrain(GeoParam.TOP, Constraint.relative(clearAllButton.get(GeoParam.TOP), 1));
+        clearAllButton.setLabel(clearLabel);
+        clearAllButton.onClick(() -> {
+            NotificationWindowRegistry.clearAll(windowId);
+            refreshEntries();
+        });
+
+        // Scrollable entry list
+        this.entryList = new GuiScrolling(getBackground());
+        this.entryList.constrain(GeoParam.LEFT, Constraint.match(getBackground().get(GeoParam.LEFT)))
+                      .constrain(GeoParam.RIGHT, Constraint.match(getBackground().get(GeoParam.RIGHT)))
+                      .constrain(GeoParam.TOP, Constraint.match(getHeaderBar().get(GeoParam.BOTTOM)))
+                      .constrain(GeoParam.BOTTOM, Constraint.match(getBackground().get(GeoParam.BOTTOM)));
+
+        // Listen for new entries
+        this.listener = (wId, entry) -> {
+            if (!wId.equals(windowId)) return;
+            refreshEntries();
+            if (entry.severity() == NotificationSeverity.ALERT && !entry.read()) {
+                isPulsing = true;
+                pulseEffect.reset();
+                getHeaderBar().fill(() -> pulseEffect.getColor());
+            }
+        };
+        NotificationWindowRegistry.addListener(listener);
+
+        // Close button
+        getCloseButton().setOpaque(true);
+        getCloseButton().onClick(() -> {
+            dispose();
+            if (windowManager != null) windowManager.removeWindow(this);
+        });
+
+        GuiRectangle closeBg = new GuiRectangle(getCloseButton());
+        net.creeperhost.polylib.client.modulargui.lib.Constraints.bind(closeBg, getCloseButton());
+        closeBg.fill(() -> getCloseButton().isMouseOver() ? 0xFFCC4444 : 0xFF993333);
+
+        refreshEntries();
+    }
+
+    public Identifier getWindowId() { return windowId; }
+
+    public FloatingNotificationWindow setWindowManager(ChatWindowManager manager) {
+        this.windowManager = manager;
+        return this;
+    }
+
+    @Override
+    public void tick(double mouseX, double mouseY) {
+        super.tick(mouseX, mouseY);
+        if (isPulsing) {
+            pulseEffect.tick();
+            if (!hasUnreadAlerts()) {
+                isPulsing = false;
+                getHeaderBar().fill(NORMAL_HEADER_COLOR);
+            }
+        }
+    }
+
+    @Override
+    public boolean mouseClicked(double mouseX, double mouseY, int button) {
+        boolean result = super.mouseClicked(mouseX, mouseY, button);
+        if (isMouseOver() && isPulsing) {
+            isPulsing = false;
+            getHeaderBar().fill(NORMAL_HEADER_COLOR);
+        }
+        return result;
+    }
+
+    private boolean hasUnreadAlerts() {
+        return NotificationWindowRegistry.getEntries(windowId).stream()
+                .anyMatch(e -> e.severity() == NotificationSeverity.ALERT && !e.read());
+    }
+
+    private void refreshEntries() {
+        int unread = NotificationWindowRegistry.getUnreadCount(windowId);
+        badgeText.setText(unread > 0
+                ? Component.literal("(" + unread + ")")
+                : Component.empty());
+
+        GuiElement<?> content = entryList.getContentElement();
+        new ArrayList<>(content.getChildren()).forEach(content::removeChild);
+        content.constrain(GeoParam.WIDTH, Constraint.match(entryList.get(GeoParam.WIDTH)));
+
+        List<NotificationEntry> entries = NotificationWindowRegistry.getEntries(windowId);
+        GuiElement<?> lastElement = null;
+
+        for (NotificationEntry entry : entries) {
+            GuiElement<?> row = new GuiElement<>(content);
+            row.constrain(GeoParam.LEFT, Constraint.match(content.get(GeoParam.LEFT)));
+            row.constrain(GeoParam.RIGHT, Constraint.match(content.get(GeoParam.RIGHT)));
+            if (lastElement == null) {
+                row.constrain(GeoParam.TOP, Constraint.match(content.get(GeoParam.TOP)));
+            } else {
+                row.constrain(GeoParam.TOP, Constraint.match(lastElement.get(GeoParam.BOTTOM)));
+            }
+
+            // Severity color bar on left edge
+            GuiRectangle severityBar = new GuiRectangle(row);
+            severityBar.constrain(GeoParam.LEFT, Constraint.match(row.get(GeoParam.LEFT)))
+                       .constrain(GeoParam.TOP, Constraint.match(row.get(GeoParam.TOP)))
+                       .constrain(GeoParam.BOTTOM, Constraint.match(row.get(GeoParam.BOTTOM)))
+                       .constrain(GeoParam.WIDTH, Constraint.literal(3))
+                       .fill(entry.read() ? 0xFF444444 : entry.severity().getColor());
+
+            // Title
+            GuiText titleText = new GuiText(row);
+            titleText.setText(entry.title());
+            titleText.constrain(GeoParam.LEFT, Constraint.relative(row.get(GeoParam.LEFT), 6))
+                     .constrain(GeoParam.TOP, Constraint.relative(row.get(GeoParam.TOP), 2))
+                     .constrain(GeoParam.RIGHT, Constraint.relative(row.get(GeoParam.RIGHT), -44))
+                     .setShadow(true);
+
+            // Timestamp (right-aligned)
+            String timeStr = new SimpleDateFormat("HH:mm").format(new Date(entry.timestamp()));
+            GuiText timeText = new GuiText(row, Component.literal(timeStr));
+            timeText.constrain(GeoParam.RIGHT, Constraint.relative(row.get(GeoParam.RIGHT), -4))
+                    .constrain(GeoParam.TOP, Constraint.relative(row.get(GeoParam.TOP), 2))
+                    .setAlignment(Align.MAX);
+
+            // Body
+            GuiText bodyText = new GuiText(row);
+            bodyText.setText(entry.body());
+            bodyText.constrain(GeoParam.LEFT, Constraint.relative(row.get(GeoParam.LEFT), 6))
+                    .constrain(GeoParam.TOP, Constraint.relative(titleText.get(GeoParam.BOTTOM), 1))
+                    .constrain(GeoParam.RIGHT, Constraint.relative(row.get(GeoParam.RIGHT), -4))
+                    .setWrap(true).setAlignment(Align.MIN).autoHeight();
+
+            row.constrain(GeoParam.HEIGHT, Constraint.relative(bodyText.get(GeoParam.HEIGHT), 14));
+
+            // Row background (dim if read)
+            GuiRectangle rowBg = new GuiRectangle(row);
+            net.creeperhost.polylib.client.modulargui.lib.Constraints.bind(rowBg, row);
+            rowBg.fill(entry.read() ? 0x22FFFFFF : 0x44FFFFFF);
+
+            // Clickable overlay to mark read
+            final NotificationEntry entryRef = entry;
+            if (!entry.read()) {
+                GuiButton rowBtn = new GuiButton(row);
+                rowBtn.constrain(GeoParam.LEFT, Constraint.match(row.get(GeoParam.LEFT)))
+                      .constrain(GeoParam.RIGHT, Constraint.match(row.get(GeoParam.RIGHT)))
+                      .constrain(GeoParam.TOP, Constraint.match(row.get(GeoParam.TOP)))
+                      .constrain(GeoParam.BOTTOM, Constraint.match(row.get(GeoParam.BOTTOM)));
+                rowBtn.onClick(() -> {
+                    NotificationWindowRegistry.markRead(windowId, entryRef.entryId());
+                    refreshEntries();
+                });
+            }
+
+            lastElement = row;
+        }
+    }
+
+    /**
+     * Unregister listeners. Call before closing/removing this window.
+     */
+    public void dispose() {
+        NotificationWindowRegistry.removeListener(listener);
+    }
+}

--- a/common/src/main/java/net/creeperhost/polylib/chat/client/notification/NotificationEntry.java
+++ b/common/src/main/java/net/creeperhost/polylib/chat/client/notification/NotificationEntry.java
@@ -1,0 +1,37 @@
+package net.creeperhost.polylib.chat.client.notification;
+
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.Identifier;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.UUID;
+
+/**
+ * A single notification pushed by a mod.
+ */
+public record NotificationEntry(
+    UUID entryId,
+    Identifier sourceId,
+    Component title,
+    Component body,
+    @Nullable Identifier icon,
+    long timestamp,
+    NotificationSeverity severity,
+    boolean read
+) {
+    public NotificationEntry markRead() {
+        return new NotificationEntry(entryId, sourceId, title, body, icon, timestamp, severity, true);
+    }
+
+    public static NotificationEntry create(Identifier sourceId, Component title, Component body,
+                                           NotificationSeverity severity) {
+        return new NotificationEntry(UUID.randomUUID(), sourceId, title, body, null,
+                System.currentTimeMillis(), severity, false);
+    }
+
+    public static NotificationEntry create(Identifier sourceId, Component title, Component body,
+                                           @Nullable Identifier icon, NotificationSeverity severity) {
+        return new NotificationEntry(UUID.randomUUID(), sourceId, title, body, icon,
+                System.currentTimeMillis(), severity, false);
+    }
+}

--- a/common/src/main/java/net/creeperhost/polylib/chat/client/notification/NotificationSeverity.java
+++ b/common/src/main/java/net/creeperhost/polylib/chat/client/notification/NotificationSeverity.java
@@ -1,0 +1,17 @@
+package net.creeperhost.polylib.chat.client.notification;
+
+/**
+ * Severity level for a notification entry.
+ * ALERT entries trigger window border pulse.
+ */
+public enum NotificationSeverity {
+    INFO(0xFF888888),     // gray indicator
+    WARNING(0xFFFFAA00),  // yellow indicator
+    ALERT(0xFFFF4444);    // red indicator, triggers pulse
+
+    private final int color;
+
+    NotificationSeverity(int color) { this.color = color; }
+
+    public int getColor() { return color; }
+}

--- a/common/src/main/java/net/creeperhost/polylib/chat/client/notification/NotificationWindowManager.java
+++ b/common/src/main/java/net/creeperhost/polylib/chat/client/notification/NotificationWindowManager.java
@@ -1,0 +1,67 @@
+package net.creeperhost.polylib.chat.client.notification;
+
+import net.creeperhost.polylib.chat.client.ChatWindowManager;
+import net.creeperhost.polylib.client.modulargui.lib.geometry.Constraint;
+import net.creeperhost.polylib.client.modulargui.lib.geometry.GeoParam;
+import net.creeperhost.polylib.client.modulargui.lib.geometry.GuiParent;
+import net.minecraft.resources.Identifier;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Manages FloatingNotificationWindow instances for FLOATING-mode notification windows.
+ */
+public class NotificationWindowManager {
+
+    private final ChatWindowManager windowManager;
+    private final Map<Identifier, FloatingNotificationWindow> activeWindows = new HashMap<>();
+
+    public NotificationWindowManager(ChatWindowManager windowManager) {
+        this.windowManager = windowManager;
+    }
+
+    /**
+     * Open a floating notification window if one isn't already open.
+     */
+    public FloatingNotificationWindow openWindow(GuiParent<?> parent, Identifier windowId) {
+        if (activeWindows.containsKey(windowId)) {
+            return activeWindows.get(windowId);
+        }
+        FloatingNotificationWindow window = new FloatingNotificationWindow(parent, windowId);
+        window.setWindowManager(windowManager);
+        window.constrain(GeoParam.LEFT, Constraint.literal(10))
+              .constrain(GeoParam.TOP, Constraint.literal(10))
+              .constrain(GeoParam.WIDTH, Constraint.literal(260))
+              .constrain(GeoParam.HEIGHT, Constraint.literal(160));
+        windowManager.addWindow(window);
+        activeWindows.put(windowId, window);
+        return window;
+    }
+
+    /**
+     * Close a floating notification window.
+     */
+    public void closeWindow(Identifier windowId) {
+        FloatingNotificationWindow window = activeWindows.remove(windowId);
+        if (window != null) {
+            window.dispose();
+            windowManager.removeWindow(window);
+        }
+    }
+
+    public boolean isOpen(Identifier windowId) {
+        return activeWindows.containsKey(windowId);
+    }
+
+    /**
+     * Open all FLOATING-mode registered windows.
+     */
+    public void restoreFloatingWindows(GuiParent<?> parent) {
+        for (NotificationWindowRegistry.WindowState state : NotificationWindowRegistry.getAllWindows()) {
+            if (state.getMode() == NotificationWindowMode.FLOATING) {
+                openWindow(parent, state.getWindowId());
+            }
+        }
+    }
+}

--- a/common/src/main/java/net/creeperhost/polylib/chat/client/notification/NotificationWindowMode.java
+++ b/common/src/main/java/net/creeperhost/polylib/chat/client/notification/NotificationWindowMode.java
@@ -1,0 +1,11 @@
+package net.creeperhost.polylib.chat.client.notification;
+
+/**
+ * How a notification window is displayed.
+ */
+public enum NotificationWindowMode {
+    FLOATING,
+    TAB_TOP,
+    TAB_SIDE_LEFT,
+    TAB_SIDE_RIGHT
+}

--- a/common/src/main/java/net/creeperhost/polylib/chat/client/notification/NotificationWindowRegistry.java
+++ b/common/src/main/java/net/creeperhost/polylib/chat/client/notification/NotificationWindowRegistry.java
@@ -1,0 +1,135 @@
+package net.creeperhost.polylib.chat.client.notification;
+
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.Identifier;
+
+import java.util.*;
+
+/**
+ * Registry for notification windows. Mods register named windows and push entries to them.
+ */
+public class NotificationWindowRegistry {
+
+    private static final Map<Identifier, WindowState> windows = new LinkedHashMap<>();
+    private static final List<NotificationListener> listeners = new ArrayList<>();
+
+    /**
+     * Register a named notification window.
+     */
+    public static void register(Identifier windowId, Component title, NotificationWindowMode mode) {
+        windows.put(windowId, new WindowState(windowId, title, mode));
+    }
+
+    /**
+     * Unregister a notification window.
+     */
+    public static void unregister(Identifier windowId) {
+        windows.remove(windowId);
+    }
+
+    /**
+     * Send a notification entry to a specific window.
+     */
+    public static void send(Identifier windowId, NotificationEntry entry) {
+        WindowState state = windows.get(windowId);
+        if (state == null) return;
+        state.entries.add(entry);
+        if (state.entries.size() > 500) {
+            state.entries.remove(0);
+        }
+        List<NotificationListener> snapshot = new ArrayList<>(listeners);
+        for (NotificationListener l : snapshot) {
+            l.onNotification(windowId, entry);
+        }
+    }
+
+    /**
+     * Get all entries for a window, oldest first.
+     */
+    public static List<NotificationEntry> getEntries(Identifier windowId) {
+        WindowState state = windows.get(windowId);
+        return state != null ? Collections.unmodifiableList(state.entries) : List.of();
+    }
+
+    /**
+     * Get the unread count for a window.
+     */
+    public static int getUnreadCount(Identifier windowId) {
+        WindowState state = windows.get(windowId);
+        if (state == null) return 0;
+        return (int) state.entries.stream().filter(e -> !e.read()).count();
+    }
+
+    /**
+     * Mark a specific entry as read.
+     */
+    public static void markRead(Identifier windowId, UUID entryId) {
+        WindowState state = windows.get(windowId);
+        if (state == null) return;
+        state.entries.replaceAll(e -> e.entryId().equals(entryId) ? e.markRead() : e);
+    }
+
+    /**
+     * Mark all entries in a window as read.
+     */
+    public static void markAllRead(Identifier windowId) {
+        WindowState state = windows.get(windowId);
+        if (state == null) return;
+        state.entries.replaceAll(NotificationEntry::markRead);
+    }
+
+    /**
+     * Clear all entries from a window.
+     */
+    public static void clearAll(Identifier windowId) {
+        WindowState state = windows.get(windowId);
+        if (state != null) state.entries.clear();
+    }
+
+    public static boolean isRegistered(Identifier windowId) {
+        return windows.containsKey(windowId);
+    }
+
+    public static WindowState getWindowState(Identifier windowId) {
+        return windows.get(windowId);
+    }
+
+    public static Collection<WindowState> getAllWindows() {
+        return Collections.unmodifiableCollection(windows.values());
+    }
+
+    public static void addListener(NotificationListener listener) {
+        listeners.add(listener);
+    }
+
+    public static void removeListener(NotificationListener listener) {
+        listeners.remove(listener);
+    }
+
+    /**
+     * Mutable state holder for a registered window.
+     */
+    public static class WindowState {
+        private final Identifier windowId;
+        private final Component title;
+        private NotificationWindowMode mode;
+        final List<NotificationEntry> entries = new ArrayList<>();
+
+        public WindowState(Identifier windowId, Component title, NotificationWindowMode mode) {
+            this.windowId = windowId;
+            this.title = title;
+            this.mode = mode;
+        }
+
+        public Identifier getWindowId() { return windowId; }
+        public Component getTitle() { return title; }
+        public NotificationWindowMode getMode() { return mode; }
+        public void setMode(NotificationWindowMode mode) { this.mode = mode; }
+        public List<NotificationEntry> getEntries() { return Collections.unmodifiableList(entries); }
+    }
+
+    @FunctionalInterface
+    public interface NotificationListener {
+        void onNotification(Identifier windowId, NotificationEntry entry);
+    }
+}

--- a/common/src/main/java/net/creeperhost/polylib/chat/client/notification/PolyNotifications.java
+++ b/common/src/main/java/net/creeperhost/polylib/chat/client/notification/PolyNotifications.java
@@ -1,0 +1,62 @@
+package net.creeperhost.polylib.chat.client.notification;
+
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.Identifier;
+
+/**
+ * Convenience API for the built-in shared PolyLib notification window.
+ * All mods sending to {@link #send(NotificationEntry)} share one consolidated panel.
+ */
+public class PolyNotifications {
+
+    public static final Identifier SHARED_WINDOW_ID =
+            Identifier.fromNamespaceAndPath("polylib", "notifications");
+
+    private static boolean initialized = false;
+
+    /**
+     * Ensure the shared window is registered. Called lazily on first send,
+     * or explicitly during client init.
+     */
+    public static void init() {
+        if (!initialized) {
+            NotificationWindowRegistry.register(
+                SHARED_WINDOW_ID,
+                Component.literal("Notifications"),
+                NotificationWindowMode.FLOATING
+            );
+            initialized = true;
+        }
+    }
+
+    /**
+     * Send a notification to the shared PolyLib notification window.
+     */
+    public static void send(NotificationEntry entry) {
+        init();
+        NotificationWindowRegistry.send(SHARED_WINDOW_ID, entry);
+    }
+
+    /**
+     * Get the unread count on the shared window.
+     */
+    public static int getUnreadCount() {
+        return NotificationWindowRegistry.getUnreadCount(SHARED_WINDOW_ID);
+    }
+
+    /**
+     * Mark all shared notifications as read.
+     */
+    public static void markAllRead() {
+        NotificationWindowRegistry.markAllRead(SHARED_WINDOW_ID);
+    }
+
+    /**
+     * Clear all shared notifications.
+     */
+    public static void clearAll() {
+        NotificationWindowRegistry.clearAll(SHARED_WINDOW_ID);
+    }
+
+    private PolyNotifications() {}
+}

--- a/common/src/main/java/net/creeperhost/polylib/chat/client/tab/AllTab.java
+++ b/common/src/main/java/net/creeperhost/polylib/chat/client/tab/AllTab.java
@@ -1,0 +1,3 @@
+package net.creeperhost.polylib.chat.client.tab;
+
+public record AllTab() implements ChatTab {}

--- a/common/src/main/java/net/creeperhost/polylib/chat/client/tab/ChannelTab.java
+++ b/common/src/main/java/net/creeperhost/polylib/chat/client/tab/ChannelTab.java
@@ -1,0 +1,5 @@
+package net.creeperhost.polylib.chat.client.tab;
+
+import net.creeperhost.polylib.chat.ChatChannel;
+
+public record ChannelTab(ChatChannel channel) implements ChatTab {}

--- a/common/src/main/java/net/creeperhost/polylib/chat/client/tab/ChatTab.java
+++ b/common/src/main/java/net/creeperhost/polylib/chat/client/tab/ChatTab.java
@@ -1,0 +1,8 @@
+package net.creeperhost.polylib.chat.client.tab;
+
+import net.minecraft.resources.Identifier;
+
+/**
+ * Sealed interface for tab types shown in the vanilla chat tab bar.
+ */
+public sealed interface ChatTab permits VanillaTab, AllTab, ChannelTab, NotificationTab {}

--- a/common/src/main/java/net/creeperhost/polylib/chat/client/tab/ChatTabBarElement.java
+++ b/common/src/main/java/net/creeperhost/polylib/chat/client/tab/ChatTabBarElement.java
@@ -1,0 +1,169 @@
+package net.creeperhost.polylib.chat.client.tab;
+
+import net.creeperhost.polylib.chat.ChatChannel;
+import net.creeperhost.polylib.chat.client.ChatNotifications;
+import net.creeperhost.polylib.chat.client.PulseEffect;
+import net.creeperhost.polylib.chat.client.notification.NotificationWindowRegistry;
+import net.creeperhost.polylib.client.modulargui.elements.GuiElement;
+import net.creeperhost.polylib.client.modulargui.lib.BackgroundRender;
+import net.creeperhost.polylib.client.modulargui.lib.GuiRender;
+import net.creeperhost.polylib.client.modulargui.lib.geometry.GuiParent;
+import net.minecraft.resources.Identifier;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public abstract class ChatTabBarElement extends GuiElement<ChatTabBarElement> implements BackgroundRender {
+    protected static final int TAB_HEIGHT = 14;
+    protected static final int TAB_PAD = 2;
+    protected static final int BG_COLOR = 0xCC202020;
+    protected static final int ACTIVE_COLOR = 0xFF4488CC;
+    protected static final int HOVER_COLOR = 0xFF336699;
+    protected static final int INACTIVE_COLOR = 0xFF333333;
+    protected static final int TEAR_OFF_THRESHOLD = 20;
+
+    protected final ChatTabRegistry registry;
+    protected final List<TabHitBox> tabBoxes = new ArrayList<>();
+
+    // Drag tracking for tear-off / rearrange
+    private boolean dragTracking = false;
+    private double dragStartX, dragStartY;
+    private ChatTab dragTab;
+    private ChatChannel dragChannel; // null for VanillaTab / AllTab
+
+    // Tick counter for pulse animation
+    protected int tabTickCounter = 0;
+
+    public ChatTabBarElement(GuiParent<?> parent) {
+        super(parent);
+        this.registry = ChatTabRegistry.get();
+    }
+
+    @Override
+    public void tick(double mouseX, double mouseY) {
+        super.tick(mouseX, mouseY);
+        tabTickCounter++;
+    }
+
+    protected boolean isActive(ChatTab tab) {
+        ChatTab active = registry.getActiveTab();
+        return switch (tab) {
+            case VanillaTab v -> active instanceof VanillaTab;
+            case AllTab a -> active instanceof AllTab;
+            case ChannelTab ct -> active instanceof ChannelTab act
+                && ct.channel().getChannelId().equals(act.channel().getChannelId());
+            case NotificationTab nt -> active instanceof NotificationTab ant
+                && nt.windowId().equals(ant.windowId());
+        };
+    }
+
+    protected String getTabLabel(ChatTab tab) {
+        return switch (tab) {
+            case VanillaTab v -> "Vanilla";
+            case AllTab a -> "All";
+            case ChannelTab ct -> ct.channel().getName().getString();
+            case NotificationTab nt -> {
+                ChatTabRegistry.NotificationTabEntry ne = registry.getNotificationEntry(nt.windowId());
+                yield ne != null ? ne.title().getString() : "Notifications";
+            }
+        };
+    }
+
+    @Override
+    public boolean mouseClicked(double mouseX, double mouseY, int button) {
+        if (button != 0) return false;
+        for (TabHitBox box : tabBoxes) {
+            if (mouseX >= box.x && mouseX < box.x + box.w && mouseY >= box.y && mouseY < box.y + box.h) {
+                registry.setActiveTab(box.tab);
+                // Clear pulse when a channel tab is clicked
+                if (box.tab instanceof ChannelTab ct) {
+                    ChatNotifications.clearPulse(ct.channel().getChannelId());
+                }
+                // Start drag tracking for all tab types
+                dragTracking = true;
+                dragStartX = mouseX;
+                dragStartY = mouseY;
+                dragTab = box.tab;
+                dragChannel = (box.tab instanceof ChannelTab ct) ? ct.channel() : null;
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public void mouseMoved(double mouseX, double mouseY) {
+        super.mouseMoved(mouseX, mouseY);
+        if (!dragTracking || dragTab == null) return;
+
+        if (dragTab instanceof ChannelTab && shouldTearOff(mouseX, mouseY) && registry.hasTearOffCallback()) {
+            // Capture source position; do NOT unregister — the channel must stay in entries
+            // so it can be found by the restore loop when chat is reopened.
+            // markFloating() is called inside the tear-off callback.
+            TabPosition sourcePos = registry.getTabPosition(dragChannel.getChannelId());
+            if (sourcePos == null) sourcePos = TabPosition.TOP;
+            registry.fireTearOffCallback(dragChannel, mouseX, mouseY, sourcePos);
+            dragTracking = false;
+            dragTab = null;
+            dragChannel = null;
+            return;
+        }
+
+        // Drag-to-reorder: swap any tab (Vanilla, All, or channel) when cursor enters another tab's bounds
+        Identifier dragId = dragTab instanceof ChannelTab ct ? ct.channel().getChannelId()
+                          : dragTab instanceof VanillaTab   ? ChatTabRegistry.VANILLA_TAB_ID
+                          : dragTab instanceof AllTab       ? ChatTabRegistry.ALL_TAB_ID
+                          : null;
+        if (dragId != null) {
+            for (TabHitBox box : tabBoxes) {
+                if (mouseX >= box.x && mouseX < box.x + box.w && mouseY >= box.y && mouseY < box.y + box.h) {
+                    Identifier boxId = box.tab instanceof ChannelTab ct2 ? ct2.channel().getChannelId()
+                                     : box.tab instanceof VanillaTab     ? ChatTabRegistry.VANILLA_TAB_ID
+                                     : box.tab instanceof AllTab         ? ChatTabRegistry.ALL_TAB_ID
+                                     : null;
+                    if (boxId != null && !boxId.equals(dragId)) {
+                        registry.swapOrder(dragId, boxId);
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
+    public boolean mouseReleased(double mouseX, double mouseY, int button) {
+        if (dragTracking && dragTab != null) {
+            // Check for cross-bar drag
+            handleCrossBarDrop(dragChannel, mouseX, mouseY);
+            dragTracking = false;
+            dragTab = null;
+            dragChannel = null;
+        }
+        return super.mouseReleased(mouseX, mouseY, button);
+    }
+
+    /**
+     * Subclasses implement this to determine tear-off direction.
+     * Top bar tears off on vertical drag, side bar on horizontal drag.
+     */
+    protected abstract boolean shouldTearOff(double mouseX, double mouseY);
+
+    /**
+     * Subclasses implement this to check if drop is over the opposite bar.
+     * {@code channel} is null for VanillaTab / AllTab drags.
+     */
+    protected abstract void handleCrossBarDrop(@Nullable ChatChannel channel, double mouseX, double mouseY);
+
+    protected double getDragStartX() { return dragStartX; }
+    protected double getDragStartY() { return dragStartY; }
+    protected ChatTab getDragTab() { return dragTab; }
+
+    /** True if (mouseX, mouseY) falls within the bounds of the given bar element. */
+    protected static boolean inBar(ChatTabBarElement bar, double mouseX, double mouseY) {
+        return mouseX >= bar.xMin() && mouseX <= bar.xMax()
+            && mouseY >= bar.yMin() && mouseY <= bar.yMax();
+    }
+
+    protected record TabHitBox(int x, int y, int w, int h, ChatTab tab) {}
+}

--- a/common/src/main/java/net/creeperhost/polylib/chat/client/tab/ChatTabBarSide.java
+++ b/common/src/main/java/net/creeperhost/polylib/chat/client/tab/ChatTabBarSide.java
@@ -1,0 +1,139 @@
+package net.creeperhost.polylib.chat.client.tab;
+
+import net.creeperhost.polylib.chat.ChatChannel;
+import net.creeperhost.polylib.chat.client.ChatNotifications;
+import net.creeperhost.polylib.chat.client.PulseEffect;
+import net.creeperhost.polylib.chat.client.notification.NotificationWindowRegistry;
+import net.creeperhost.polylib.client.modulargui.lib.GuiRender;
+import net.creeperhost.polylib.client.modulargui.lib.geometry.GuiParent;
+import net.minecraft.client.gui.Font;
+import net.minecraft.resources.Identifier;
+import org.jetbrains.annotations.Nullable;
+import org.joml.Matrix3x2fStack;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ChatTabBarSide extends ChatTabBarElement {
+    private static final int TAB_WIDTH = 16;
+    private final TabPosition side;
+
+    public ChatTabBarSide(GuiParent<?> parent, TabPosition side) {
+        super(parent);
+        this.side = side;
+    }
+
+    public TabPosition getSide() { return side; }
+
+    private List<ChatTab> collectTabs() {
+        List<ChatTab> tabs = new ArrayList<>();
+        for (Identifier id : registry.getOrderList(side)) {
+            if (id.equals(ChatTabRegistry.VANILLA_TAB_ID) && registry.shouldShowVanillaTab()) {
+                tabs.add(new VanillaTab());
+            } else if (id.equals(ChatTabRegistry.ALL_TAB_ID) && registry.shouldShowAllTab()) {
+                tabs.add(new AllTab());
+            } else {
+                if (registry.getFloatingChannels().contains(id)) continue; // shown as floating window
+                ChatTabRegistry.TabEntry e = registry.getEntry(id);
+                if (e != null && e.position() == side) {
+                    tabs.add(new ChannelTab(e.channel()));
+                } else {
+                    ChatTabRegistry.NotificationTabEntry ne = registry.getNotificationEntry(id);
+                    if (ne != null && ne.position() == side) tabs.add(new NotificationTab(id));
+                }
+            }
+        }
+        return tabs;
+    }
+
+    @Override
+    protected boolean shouldTearOff(double mouseX, double mouseY) {
+        return Math.abs(mouseX - getDragStartX()) > TEAR_OFF_THRESHOLD;
+    }
+
+    @Override
+    protected void handleCrossBarDrop(@Nullable ChatChannel channel, double mouseX, double mouseY) {
+        ChatTabBarTop topBar = ChatTabInjection.getTopBar();
+        ChatTabBarSide leftBar = ChatTabInjection.getSideBarLeft();
+        ChatTabBarSide rightBar = ChatTabInjection.getSideBarRight();
+        if (topBar != null && inBar(topBar, mouseX, mouseY)) {
+            if (channel != null) {
+                registry.unregister(channel.getChannelId());
+                registry.registerTop(channel);
+            } else {
+                ChatTab dragging = getDragTab();
+                if (dragging instanceof VanillaTab) registry.setVanillaTabPosition(TabPosition.TOP);
+                else if (dragging instanceof AllTab) registry.setAllTabPosition(TabPosition.TOP);
+            }
+        } else if (side == TabPosition.SIDE_LEFT && rightBar != null && rightBar.isEnabled() && inBar(rightBar, mouseX, mouseY)) {
+            if (channel != null) { registry.unregister(channel.getChannelId()); registry.registerSideRight(channel); }
+            else { ChatTab d = getDragTab(); if (d instanceof VanillaTab) registry.setVanillaTabPosition(TabPosition.SIDE_RIGHT); else if (d instanceof AllTab) registry.setAllTabPosition(TabPosition.SIDE_RIGHT); }
+        } else if (side == TabPosition.SIDE_RIGHT && leftBar != null && leftBar.isEnabled() && inBar(leftBar, mouseX, mouseY)) {
+            if (channel != null) { registry.unregister(channel.getChannelId()); registry.registerSideLeft(channel); }
+            else { ChatTab d = getDragTab(); if (d instanceof VanillaTab) registry.setVanillaTabPosition(TabPosition.SIDE_LEFT); else if (d instanceof AllTab) registry.setAllTabPosition(TabPosition.SIDE_LEFT); }
+        }
+    }
+
+    @Override
+    public void renderBehind(GuiRender render, double mouseX, double mouseY, float partialTicks) {
+        List<ChatTab> tabs = collectTabs();
+        tabBoxes.clear();
+        if (tabs.isEmpty()) return;
+
+        Font font = render.font();
+        int x = (int) xMin();
+        int y = (int) yMin();
+
+        // Draw bar background
+        render.rect(xMin(), yMin(), (double) TAB_WIDTH, ySize(), BG_COLOR);
+
+        for (ChatTab tab : tabs) {
+            String label = getTabLabel(tab);
+            int textWidth = font.width(label);
+            int tabHeight = textWidth + TAB_PAD * 2 + 4;
+            boolean active = isActive(tab);
+            boolean hovered = mouseX >= x && mouseX < x + TAB_WIDTH && mouseY >= y && mouseY < y + tabHeight;
+
+            int color = active ? ACTIVE_COLOR : hovered ? HOVER_COLOR : INACTIVE_COLOR;
+            render.rect(x, y, TAB_WIDTH, tabHeight, color);
+
+            // Pulse border for channel tabs
+            if (tab instanceof ChannelTab ct && ChatNotifications.isPulsing(ct.channel().getChannelId())) {
+                int pulseColor = PulseEffect.colorForTick(tabTickCounter);
+                render.rect(x, y, TAB_WIDTH, 2, pulseColor);              // top edge
+                render.rect(x, y + tabHeight - 2, TAB_WIDTH, 2, pulseColor); // bottom edge
+                render.rect(x, y, 2, tabHeight, pulseColor);              // left edge
+                render.rect(x + TAB_WIDTH - 2, y, 2, tabHeight, pulseColor); // right edge
+            }
+
+            // Unread badge for notification tabs
+            if (tab instanceof NotificationTab nt) {
+                int unread = NotificationWindowRegistry.getUnreadCount(nt.windowId());
+                if (unread > 0) {
+                    render.rect(x, y, TAB_WIDTH, 8, 0xFFFF4444);
+                    render.drawString(String.valueOf(Math.min(unread, 99)), x + 1, y + 1, 0xFFFFFFFF, false);
+                }
+            }
+
+            // Unread badge for notification tabs
+            if (tab instanceof NotificationTab nt) {
+                int unread = NotificationWindowRegistry.getUnreadCount(nt.windowId());
+                if (unread > 0) {
+                    render.rect(x, y, TAB_WIDTH, 8, 0xFFFF4444);
+                    render.drawString(String.valueOf(Math.min(unread, 99)), x + 1, y + 1, 0xFFFFFFFF, false);
+                }
+            }
+
+            // Rotate text 90° for vertical display
+            Matrix3x2fStack poses = render.pose();
+            poses.pushMatrix();
+            poses.translate((float) (x + TAB_WIDTH - 3), (float) (y + TAB_PAD + 2));
+            poses.rotate((float) Math.toRadians(90));
+            render.drawString(label, 0, 0, 0xFFFFFFFF, true);
+            poses.popMatrix();
+
+            tabBoxes.add(new TabHitBox(x, y, TAB_WIDTH, tabHeight, tab));
+            y += tabHeight + 1;
+        }
+    }
+}

--- a/common/src/main/java/net/creeperhost/polylib/chat/client/tab/ChatTabBarTop.java
+++ b/common/src/main/java/net/creeperhost/polylib/chat/client/tab/ChatTabBarTop.java
@@ -1,0 +1,133 @@
+package net.creeperhost.polylib.chat.client.tab;
+
+import net.creeperhost.polylib.chat.ChatChannel;
+import net.creeperhost.polylib.chat.client.ChatNotifications;
+import net.creeperhost.polylib.chat.client.PulseEffect;
+import net.creeperhost.polylib.chat.client.notification.NotificationWindowRegistry;
+import net.creeperhost.polylib.client.modulargui.lib.GuiRender;
+import net.creeperhost.polylib.client.modulargui.lib.geometry.GuiParent;
+import net.minecraft.client.gui.Font;
+import net.minecraft.resources.Identifier;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ChatTabBarTop extends ChatTabBarElement {
+
+    public ChatTabBarTop(GuiParent<?> parent) {
+        super(parent);
+    }
+
+    private List<ChatTab> collectTabs() {
+        List<ChatTab> tabs = new ArrayList<>();
+        for (Identifier id : registry.getOrderList(TabPosition.TOP)) {
+            if (id.equals(ChatTabRegistry.VANILLA_TAB_ID) && registry.shouldShowVanillaTab()) {
+                tabs.add(new VanillaTab());
+            } else if (id.equals(ChatTabRegistry.ALL_TAB_ID) && registry.shouldShowAllTab()) {
+                tabs.add(new AllTab());
+            } else {
+                if (registry.getFloatingChannels().contains(id)) continue; // shown as floating window
+                ChatTabRegistry.TabEntry e = registry.getEntry(id);
+                if (e != null && e.position() == TabPosition.TOP) {
+                    tabs.add(new ChannelTab(e.channel()));
+                } else {
+                    ChatTabRegistry.NotificationTabEntry ne = registry.getNotificationEntry(id);
+                    if (ne != null && ne.position() == TabPosition.TOP) tabs.add(new NotificationTab(id));
+                }
+            }
+        }
+        return tabs;
+    }
+
+    @Override
+    protected boolean shouldTearOff(double mouseX, double mouseY) {
+        return Math.abs(mouseY - getDragStartY()) > TEAR_OFF_THRESHOLD;
+    }
+
+    @Override
+    protected void handleCrossBarDrop(@Nullable ChatChannel channel, double mouseX, double mouseY) {
+        // Use coordinate checks (isMouseOver is unreliable when drag started on a different element)
+        ChatTabBarSide leftBar = ChatTabInjection.getSideBarLeft();
+        ChatTabBarSide rightBar = ChatTabInjection.getSideBarRight();
+        if (leftBar != null && leftBar.isEnabled() && inBar(leftBar, mouseX, mouseY)) {
+            if (channel != null) {
+                registry.unregister(channel.getChannelId());
+                registry.registerSideLeft(channel);
+            } else {
+                ChatTab dragging = getDragTab();
+                if (dragging instanceof VanillaTab) registry.setVanillaTabPosition(TabPosition.SIDE_LEFT);
+                else if (dragging instanceof AllTab) registry.setAllTabPosition(TabPosition.SIDE_LEFT);
+            }
+        } else if (rightBar != null && rightBar.isEnabled() && inBar(rightBar, mouseX, mouseY)) {
+            if (channel != null) {
+                registry.unregister(channel.getChannelId());
+                registry.registerSideRight(channel);
+            } else {
+                ChatTab dragging = getDragTab();
+                if (dragging instanceof VanillaTab) registry.setVanillaTabPosition(TabPosition.SIDE_RIGHT);
+                else if (dragging instanceof AllTab) registry.setAllTabPosition(TabPosition.SIDE_RIGHT);
+            }
+        }
+    }
+
+    @Override
+    public void renderBehind(GuiRender render, double mouseX, double mouseY, float partialTicks) {
+        if (!registry.hasAnyChannel()) return;
+
+        List<ChatTab> tabs = collectTabs();
+        tabBoxes.clear();
+
+        Font font = render.font();
+        int x = (int) xMin();
+        int y = (int) yMin();
+        int barHeight = TAB_HEIGHT;
+
+        // Draw bar background
+        render.rect(xMin(), yMin(), xSize(), ySize(), BG_COLOR);
+
+        for (ChatTab tab : tabs) {
+            String label = getTabLabel(tab);
+            int textWidth = font.width(label);
+            int tabWidth = textWidth + TAB_PAD * 2 + 4;
+            boolean active = isActive(tab);
+            boolean hovered = mouseX >= x && mouseX < x + tabWidth && mouseY >= y && mouseY < y + barHeight;
+
+            int color = active ? ACTIVE_COLOR : hovered ? HOVER_COLOR : INACTIVE_COLOR;
+            render.rect(x, y, tabWidth, barHeight, color);
+            render.drawString(label, x + TAB_PAD + 2, y + 3, 0xFFFFFFFF, true);
+
+            // Pulse border for channel tabs
+            if (tab instanceof ChannelTab ct && ChatNotifications.isPulsing(ct.channel().getChannelId())) {
+                int pulseColor = PulseEffect.colorForTick(tabTickCounter);
+                render.rect(x, y, tabWidth, 2, pulseColor);            // top edge
+                render.rect(x, y + barHeight - 2, tabWidth, 2, pulseColor); // bottom edge
+                render.rect(x, y, 2, barHeight, pulseColor);            // left edge
+                render.rect(x + tabWidth - 2, y, 2, barHeight, pulseColor); // right edge
+            }
+
+            // Unread badge for notification tabs
+            if (tab instanceof NotificationTab nt) {
+                int unread = NotificationWindowRegistry.getUnreadCount(nt.windowId());
+                if (unread > 0) {
+                    String badge = String.valueOf(Math.min(unread, 99));
+                    render.rect(x + tabWidth - 10, y, 10, 8, 0xFFFF4444);
+                    render.drawString(badge, x + tabWidth - 9, y + 1, 0xFFFFFFFF, false);
+                }
+            }
+
+            // Unread badge for notification tabs
+            if (tab instanceof NotificationTab nt) {
+                int unread = NotificationWindowRegistry.getUnreadCount(nt.windowId());
+                if (unread > 0) {
+                    String badge = String.valueOf(Math.min(unread, 99));
+                    render.rect(x + tabWidth - 10, y, 10, 8, 0xFFFF4444);
+                    render.drawString(badge, x + tabWidth - 9, y + 1, 0xFFFFFFFF, false);
+                }
+            }
+
+            tabBoxes.add(new TabHitBox(x, y, tabWidth, barHeight, tab));
+            x += tabWidth + 1;
+        }
+    }
+}

--- a/common/src/main/java/net/creeperhost/polylib/chat/client/tab/ChatTabInjection.java
+++ b/common/src/main/java/net/creeperhost/polylib/chat/client/tab/ChatTabInjection.java
@@ -1,0 +1,221 @@
+package net.creeperhost.polylib.chat.client.tab;
+
+import net.creeperhost.polylib.chat.RichChatMessage;
+import net.creeperhost.polylib.chat.client.ChatNotifications;
+import net.creeperhost.polylib.chat.client.ChatWindowManager;
+import net.creeperhost.polylib.chat.client.FloatingChatWindow;
+import net.creeperhost.polylib.chat.client.notification.NotificationEntry;
+import net.creeperhost.polylib.chat.client.notification.NotificationWindowRegistry;
+import net.creeperhost.polylib.client.modulargui.ModularGui;
+import net.creeperhost.polylib.client.modulargui.ModularGuiInjector;
+import net.creeperhost.polylib.client.modulargui.elements.GuiElement;
+import net.creeperhost.polylib.client.modulargui.lib.BackgroundRender;
+import net.creeperhost.polylib.client.modulargui.lib.GuiProvider;
+import net.creeperhost.polylib.client.modulargui.lib.GuiRender;
+import net.creeperhost.polylib.client.modulargui.lib.geometry.Constraint;
+import net.creeperhost.polylib.client.modulargui.lib.geometry.GeoParam;
+import net.creeperhost.polylib.client.modulargui.lib.geometry.GuiParent;
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.screens.ChatScreen;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.Identifier;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+
+public final class ChatTabInjection {
+
+    private static ChatTabBarTop topBar;
+    private static ChatTabBarSide sideBarLeft;
+    private static ChatTabBarSide sideBarRight;
+    private static ChatWindowManager windowManager;
+
+    private ChatTabInjection() {}
+
+    public static ChatTabBarTop getTopBar() { return topBar; }
+    public static ChatTabBarSide getSideBarLeft() { return sideBarLeft; }
+    public static ChatTabBarSide getSideBarRight() { return sideBarRight; }
+
+    public static void init() {
+        ChatNotifications.init(); // wire mention-pulse global listener
+        ModularGuiInjector.registerInjection(
+            screen -> screen instanceof ChatScreen,
+            screen -> new ChatTabProvider()
+        );
+    }
+
+    private static class ChatTabProvider implements GuiProvider {
+
+        @Override
+        public void buildGui(ModularGui gui) {
+            gui.initFullscreenGui();
+            GuiElement<?> root = gui.getRoot();
+            ChatTabRegistry reg = ChatTabRegistry.get();
+
+            if (!reg.hasAnyChannel()) {
+                topBar = null;
+                sideBarLeft = null;
+                sideBarRight = null;
+                return;
+            }
+
+            // TOP tab bar: horizontal strip above the chat input box
+            topBar = new ChatTabBarTop(root);
+            topBar.constrain(GeoParam.LEFT, Constraint.literal(2));
+            topBar.constrain(GeoParam.RIGHT, Constraint.relative(root.get(GeoParam.RIGHT), -2));
+            topBar.constrain(GeoParam.BOTTOM, Constraint.relative(root.get(GeoParam.BOTTOM), -14));
+            topBar.constrain(GeoParam.HEIGHT, Constraint.literal(14));
+
+            // SIDE LEFT tab bar — always created so docking always works; hidden when empty and no window is being dragged
+            sideBarLeft = new ChatTabBarSide(root, TabPosition.SIDE_LEFT);
+            sideBarLeft.constrain(GeoParam.LEFT, Constraint.literal(0));
+            sideBarLeft.constrain(GeoParam.WIDTH, Constraint.literal(16));
+            sideBarLeft.constrain(GeoParam.BOTTOM, Constraint.relative(topBar.get(GeoParam.TOP), 0));
+            sideBarLeft.constrain(GeoParam.HEIGHT, Constraint.literal(200));
+            sideBarLeft.setEnabled(() -> !reg.getSideLeftEntries().isEmpty() || FloatingChatWindow.anyWindowDragging);
+
+            // SIDE RIGHT tab bar — always created so docking always works; hidden when empty and no window is being dragged
+            sideBarRight = new ChatTabBarSide(root, TabPosition.SIDE_RIGHT);
+            sideBarRight.constrain(GeoParam.RIGHT, Constraint.relative(root.get(GeoParam.RIGHT), -2));
+            sideBarRight.constrain(GeoParam.WIDTH, Constraint.literal(16));
+            sideBarRight.constrain(GeoParam.BOTTOM, Constraint.relative(topBar.get(GeoParam.TOP), 0));
+            sideBarRight.constrain(GeoParam.HEIGHT, Constraint.literal(200));
+            sideBarRight.setEnabled(() -> !reg.getSideRightEntries().isEmpty() || FloatingChatWindow.anyWindowDragging);
+
+            // Channel message history overlay — insets so it never covers active side bars
+            // left offset: 2 normally, 18 when left bar has tabs; right offset: -2 normally, -18 when right bar has tabs
+            ChannelHistoryOverlay history = new ChannelHistoryOverlay(root);
+            history.constrain(GeoParam.LEFT, Constraint.dynamic(() -> (double)(!reg.getSideLeftEntries().isEmpty() ? 18 : 2)));
+            history.constrain(GeoParam.RIGHT, Constraint.relative(root.get(GeoParam.RIGHT), 0))
+                   .constrain(GeoParam.RIGHT, Constraint.dynamic(() -> root.get(GeoParam.RIGHT).get() + (!reg.getSideRightEntries().isEmpty() ? -18 : -2)));
+            history.constrain(GeoParam.BOTTOM, Constraint.relative(root.get(GeoParam.BOTTOM), -28));
+            history.constrain(GeoParam.HEIGHT, Constraint.literal(200));
+
+            // Wire tear-off: dragging a tab out of the bar creates a floating window.
+            // After adding the floating window, re-adopt side bars to push them to the top of the render stack.
+            windowManager = new ChatWindowManager();
+            ChatTabBarSide finalSideBarLeft = sideBarLeft;
+            ChatTabBarSide finalSideBarRight = sideBarRight;
+
+            // Restore any windows that were floating when chat was last closed
+            int restoreOffset = 0;
+            for (Identifier floatingId : reg.getFloatingChannels()) {
+                ChatTabRegistry.TabEntry entry = reg.getEntry(floatingId);
+                if (entry == null) continue;
+                FloatingChatWindow restored = new FloatingChatWindow(root, entry.channel());
+                double[] pos = FloatingChatWindow.SAVED_POSITIONS.get(floatingId.toString());
+                if (pos != null) {
+                    restored.constrain(GeoParam.LEFT, Constraint.literal(pos[0]))
+                            .constrain(GeoParam.TOP, Constraint.literal(pos[1]))
+                            .constrain(GeoParam.WIDTH, Constraint.literal(pos[2]))
+                            .constrain(GeoParam.HEIGHT, Constraint.literal(pos[3]));
+                } else {
+                    restored.constrain(GeoParam.LEFT, Constraint.literal(20 + restoreOffset * 20))
+                            .constrain(GeoParam.TOP, Constraint.literal(20 + restoreOffset * 20))
+                            .constrain(GeoParam.WIDTH, Constraint.literal(280))
+                            .constrain(GeoParam.HEIGHT, Constraint.literal(200));
+                }
+                restored.applyRestoredState(); // restore minimized state now that bounds are resolved
+                windowManager.addWindow(restored);
+                restoreOffset++;
+            }
+
+            reg.setTearOffCallback(event -> {
+                reg.markFloating(event.channel().getChannelId());
+                FloatingChatWindow win = new FloatingChatWindow(root, event.channel());
+                win.setSourceTabPosition(event.sourcePosition());
+                win.constrain(GeoParam.LEFT, Constraint.literal((int) event.x() - 140))
+                   .constrain(GeoParam.TOP, Constraint.literal((int) event.y() - 10))
+                   .constrain(GeoParam.WIDTH, Constraint.literal(280))
+                   .constrain(GeoParam.HEIGHT, Constraint.literal(200));
+                windowManager.addWindow(win);
+                win.startDragging();
+                // Re-adopt side bars so they render after (on top of) the newly added floating window
+                root.adoptChild(finalSideBarLeft);
+                root.adoptChild(finalSideBarRight);
+            });
+        }
+    }
+
+    static class ChannelHistoryOverlay extends GuiElement<ChannelHistoryOverlay> implements BackgroundRender {
+        public ChannelHistoryOverlay(GuiParent<?> parent) {
+            super(parent);
+        }
+
+        @Override
+        public void renderBehind(GuiRender render, double mouseX, double mouseY, float partialTicks) {
+            ChatTabRegistry reg = ChatTabRegistry.get();
+            ChatTab active = reg.getActiveTab();
+
+            if (active instanceof VanillaTab) return;
+
+            // Background
+            render.rect(xMin(), yMin(), xSize(), ySize(), 0xCC000000);
+
+            if (active instanceof NotificationTab nt) {
+                renderNotifications(render, nt);
+                return;
+            }
+
+            List<RichChatMessage> messages = getMessagesForTab(active);
+
+            Font font = render.font();
+            int lineHeight = 10;
+            int y = (int) yMax() - 4;
+
+            for (int i = messages.size() - 1; i >= 0 && y > yMin(); i--) {
+                RichChatMessage msg = messages.get(i);
+                Component display = formatMessage(msg);
+                y -= lineHeight;
+                render.drawString(display, (double) ((int) xMin() + 4), (double) y, 0xFFFFFFFF, true);
+            }
+        }
+
+        private List<RichChatMessage> getMessagesForTab(ChatTab tab) {
+            return switch (tab) {
+                case VanillaTab v -> List.of();
+                case AllTab a -> {
+                    List<RichChatMessage> all = new ArrayList<>();
+                    for (var entry : ChatTabRegistry.get().allEntries()) {
+                        all.addAll(entry.channel().getMessages());
+                    }
+                    all.sort(Comparator.comparing(RichChatMessage::timestamp));
+                    yield all;
+                }
+                case ChannelTab ct -> ct.channel().getMessages();
+                case NotificationTab nt -> List.of();
+            };
+        }
+
+        private Component formatMessage(RichChatMessage msg) {
+            if (msg.senderName() != null) {
+                return Component.literal("<")
+                    .append(msg.senderName())
+                    .append("> ")
+                    .append(msg.content());
+            }
+            return msg.content();
+        }
+
+        private void renderNotifications(GuiRender render, NotificationTab nt) {
+            List<NotificationEntry> entries = NotificationWindowRegistry.getEntries(nt.windowId());
+            Font font = render.font();
+            int lineHeight = 10;
+            int y = (int) yMax() - 4;
+            for (int i = entries.size() - 1; i >= 0 && y > yMin(); i--) {
+                NotificationEntry entry = entries.get(i);
+                // Severity indicator color
+                int color = entry.read() ? 0xFF888888 : entry.severity().getColor();
+                Component line = Component.literal("\u2022 ")
+                    .withStyle(s -> s.withColor(color))
+                    .append(entry.title())
+                    .append(Component.literal(": "))
+                    .append(entry.body());
+                y -= lineHeight;
+                render.drawString(line, (double)((int) xMin() + 4), (double) y, 0xFFFFFFFF, true);
+            }
+        }
+    }
+}

--- a/common/src/main/java/net/creeperhost/polylib/chat/client/tab/ChatTabRegistry.java
+++ b/common/src/main/java/net/creeperhost/polylib/chat/client/tab/ChatTabRegistry.java
@@ -1,0 +1,264 @@
+package net.creeperhost.polylib.chat.client.tab;
+
+import net.creeperhost.polylib.chat.ChatChannel;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.Identifier;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+
+public final class ChatTabRegistry {
+    /** Sentinel identifier used to track the Vanilla tab's position in order lists. */
+    public static final Identifier VANILLA_TAB_ID = Identifier.fromNamespaceAndPath("polylib", "vanilla_tab");
+    /** Sentinel identifier used to track the All tab's position in order lists. */
+    public static final Identifier ALL_TAB_ID = Identifier.fromNamespaceAndPath("polylib", "all_tab");
+
+    private static final ChatTabRegistry INSTANCE = new ChatTabRegistry();
+
+    private final Map<Identifier, TabEntry> entries = new ConcurrentHashMap<>();
+    private final Map<Identifier, NotificationTabEntry> notifEntries = new ConcurrentHashMap<>();
+    private final Set<Identifier> floatingChannels = ConcurrentHashMap.newKeySet();
+    private final List<Identifier> topOrder = new ArrayList<>();
+    private final List<Identifier> sideLeftOrder = new ArrayList<>();
+    private final List<Identifier> sideRightOrder = new ArrayList<>();
+    private ChatTab activeTab = new VanillaTab();
+    private boolean showVanillaTab = true;
+    private boolean showAllTab = true;
+
+    public record TabEntry(ChatChannel channel, TabPosition position) {}
+    public record NotificationTabEntry(Identifier windowId, Component title, TabPosition position) {}
+
+    private ChatTabRegistry() {
+        // Vanilla and All tabs default to TOP, prepended to the order list
+        topOrder.add(VANILLA_TAB_ID);
+        topOrder.add(ALL_TAB_ID);
+    }
+
+    public static ChatTabRegistry get() { return INSTANCE; }
+
+    // --- Registration ---
+
+    public void registerTop(ChatChannel channel) {
+        Identifier id = channel.getChannelId();
+        entries.put(id, new TabEntry(channel, TabPosition.TOP));
+        floatingChannels.remove(id);
+        sideLeftOrder.remove(id);
+        sideRightOrder.remove(id);
+        if (!topOrder.contains(id)) topOrder.add(id);
+    }
+
+    public void registerSideLeft(ChatChannel channel) {
+        Identifier id = channel.getChannelId();
+        entries.put(id, new TabEntry(channel, TabPosition.SIDE_LEFT));
+        floatingChannels.remove(id);
+        topOrder.remove(id);
+        sideRightOrder.remove(id);
+        if (!sideLeftOrder.contains(id)) sideLeftOrder.add(id);
+    }
+
+    public void registerSideRight(ChatChannel channel) {
+        Identifier id = channel.getChannelId();
+        entries.put(id, new TabEntry(channel, TabPosition.SIDE_RIGHT));
+        floatingChannels.remove(id);
+        topOrder.remove(id);
+        sideLeftOrder.remove(id);
+        if (!sideRightOrder.contains(id)) sideRightOrder.add(id);
+    }
+
+    public void unregister(Identifier channelId) {
+        entries.remove(channelId);
+        notifEntries.remove(channelId);
+        topOrder.remove(channelId);
+        sideLeftOrder.remove(channelId);
+        sideRightOrder.remove(channelId);
+        if (activeTab instanceof ChannelTab ct && ct.channel().getChannelId().equals(channelId)) {
+            activeTab = new VanillaTab();
+        }
+        if (activeTab instanceof NotificationTab nt && nt.windowId().equals(channelId)) {
+            activeTab = new VanillaTab();
+        }
+    }
+
+    // --- Notification Tab Registration ---
+
+    public void registerNotificationTop(Identifier windowId, Component title) {
+        notifEntries.put(windowId, new NotificationTabEntry(windowId, title, TabPosition.TOP));
+        sideLeftOrder.remove(windowId);
+        sideRightOrder.remove(windowId);
+        if (!topOrder.contains(windowId)) topOrder.add(windowId);
+    }
+
+    public void registerNotificationSideLeft(Identifier windowId, Component title) {
+        notifEntries.put(windowId, new NotificationTabEntry(windowId, title, TabPosition.SIDE_LEFT));
+        topOrder.remove(windowId);
+        sideRightOrder.remove(windowId);
+        if (!sideLeftOrder.contains(windowId)) sideLeftOrder.add(windowId);
+    }
+
+    public void registerNotificationSideRight(Identifier windowId, Component title) {
+        notifEntries.put(windowId, new NotificationTabEntry(windowId, title, TabPosition.SIDE_RIGHT));
+        topOrder.remove(windowId);
+        sideLeftOrder.remove(windowId);
+        if (!sideRightOrder.contains(windowId)) sideRightOrder.add(windowId);
+    }
+
+    @org.jetbrains.annotations.Nullable
+    public NotificationTabEntry getNotificationEntry(Identifier windowId) {
+        return notifEntries.get(windowId);
+    }
+
+    // --- Active Tab ---
+
+    public ChatTab getActiveTab() { return activeTab; }
+
+    public void setActiveTab(ChatTab tab) { this.activeTab = tab; }
+
+    // --- Built-in tab positions ---
+
+    public TabPosition getVanillaTabPosition() {
+        if (sideLeftOrder.contains(VANILLA_TAB_ID)) return TabPosition.SIDE_LEFT;
+        if (sideRightOrder.contains(VANILLA_TAB_ID)) return TabPosition.SIDE_RIGHT;
+        return TabPosition.TOP;
+    }
+
+    public void setVanillaTabPosition(TabPosition pos) {
+        topOrder.remove(VANILLA_TAB_ID);
+        sideLeftOrder.remove(VANILLA_TAB_ID);
+        sideRightOrder.remove(VANILLA_TAB_ID);
+        getOrderList(pos).add(0, VANILLA_TAB_ID);
+    }
+
+    public TabPosition getAllTabPosition() {
+        if (sideLeftOrder.contains(ALL_TAB_ID)) return TabPosition.SIDE_LEFT;
+        if (sideRightOrder.contains(ALL_TAB_ID)) return TabPosition.SIDE_RIGHT;
+        return TabPosition.TOP;
+    }
+
+    public void setAllTabPosition(TabPosition pos) {
+        topOrder.remove(ALL_TAB_ID);
+        sideLeftOrder.remove(ALL_TAB_ID);
+        sideRightOrder.remove(ALL_TAB_ID);
+        getOrderList(pos).add(ALL_TAB_ID);
+    }
+
+    public boolean shouldShowVanillaTab() { return showVanillaTab && hasAnyChannel(); }
+    public void setShowVanillaTab(boolean show) { this.showVanillaTab = show; }
+
+    public boolean shouldShowAllTab() { return showAllTab && (entries.size() + floatingChannels.size()) >= 2; }
+    public void setShowAllTab(boolean show) { this.showAllTab = show; }
+
+    // --- Queries ---
+
+    public boolean hasAnyChannel() { return !entries.isEmpty() || !floatingChannels.isEmpty(); }
+
+    /** Track a channel as floating (torn off into a window). */
+    public void markFloating(Identifier channelId) { floatingChannels.add(channelId); }
+
+    /** Remove floating tracking (when window is closed/destroyed). */
+    public void unmarkFloating(Identifier channelId) { floatingChannels.remove(channelId); }
+
+    /** Returns a snapshot of all currently-floating channel IDs. */
+    public Set<Identifier> getFloatingChannels() { return Collections.unmodifiableSet(floatingChannels); }
+
+    public List<TabEntry> getTopEntries() {
+        List<TabEntry> result = new ArrayList<>();
+        for (Identifier id : topOrder) {
+            TabEntry e = entries.get(id);
+            if (e != null && e.position() == TabPosition.TOP) result.add(e);
+        }
+        return result;
+    }
+
+    public List<TabEntry> getSideLeftEntries() {
+        List<TabEntry> result = new ArrayList<>();
+        for (Identifier id : sideLeftOrder) {
+            TabEntry e = entries.get(id);
+            if (e != null && e.position() == TabPosition.SIDE_LEFT) result.add(e);
+        }
+        return result;
+    }
+
+    public List<TabEntry> getSideRightEntries() {
+        List<TabEntry> result = new ArrayList<>();
+        for (Identifier id : sideRightOrder) {
+            TabEntry e = entries.get(id);
+            if (e != null && e.position() == TabPosition.SIDE_RIGHT) result.add(e);
+        }
+        return result;
+    }
+
+    public boolean hasAnySideEntries() {
+        return entries.values().stream()
+            .anyMatch(e -> e.position() == TabPosition.SIDE_LEFT || e.position() == TabPosition.SIDE_RIGHT);
+    }
+
+    @Nullable
+    public TabEntry getEntry(Identifier channelId) {
+        return entries.get(channelId);
+    }
+
+    @Nullable
+    public TabPosition getTabPosition(Identifier channelId) {
+        TabEntry e = entries.get(channelId);
+        return e != null ? e.position() : null;
+    }
+
+    public Collection<TabEntry> allEntries() {
+        return Collections.unmodifiableCollection(entries.values());
+    }
+
+    // --- Reorder ---
+
+    /** Swap two channel tabs (by channel ID) within the same bar. */
+    public void swapOrder(Identifier a, Identifier b) {
+        // Allow swapping sentinel IDs (vanilla/all) with channel IDs or each other
+        TabPosition posA = getPositionOfId(a);
+        TabPosition posB = getPositionOfId(b);
+        if (posA == null || posB == null || posA != posB) return;
+        List<Identifier> order = getOrderList(posA);
+        int ia = order.indexOf(a);
+        int ib = order.indexOf(b);
+        if (ia >= 0 && ib >= 0) {
+            Collections.swap(order, ia, ib);
+        }
+    }
+
+    /** Returns which bar position a given ID (channel or sentinel) lives in. */
+    @Nullable
+    private TabPosition getPositionOfId(Identifier id) {
+        if (id.equals(VANILLA_TAB_ID)) return getVanillaTabPosition();
+        if (id.equals(ALL_TAB_ID)) return getAllTabPosition();
+        TabEntry e = entries.get(id);
+        return e != null ? e.position() : null;
+    }
+
+    public List<Identifier> getOrderList(TabPosition pos) {
+        return switch (pos) {
+            case TOP -> topOrder;
+            case SIDE_LEFT -> sideLeftOrder;
+            case SIDE_RIGHT -> sideRightOrder;
+        };
+    }
+
+    // --- Tear-off callback ---
+
+    public record TearOffEvent(ChatChannel channel, double x, double y, TabPosition sourcePosition) {}
+
+    private Consumer<TearOffEvent> tearOffCallback;
+
+    public void setTearOffCallback(Consumer<TearOffEvent> callback) {
+        this.tearOffCallback = callback;
+    }
+
+    public boolean hasTearOffCallback() {
+        return tearOffCallback != null;
+    }
+
+    void fireTearOffCallback(ChatChannel channel, double x, double y, TabPosition sourcePosition) {
+        if (tearOffCallback != null) {
+            tearOffCallback.accept(new TearOffEvent(channel, x, y, sourcePosition));
+        }
+    }
+}

--- a/common/src/main/java/net/creeperhost/polylib/chat/client/tab/NotificationTab.java
+++ b/common/src/main/java/net/creeperhost/polylib/chat/client/tab/NotificationTab.java
@@ -1,0 +1,8 @@
+package net.creeperhost.polylib.chat.client.tab;
+
+import net.minecraft.resources.Identifier;
+
+/**
+ * A tab representing a notification window within the chat tab bar.
+ */
+public record NotificationTab(Identifier windowId) implements ChatTab {}

--- a/common/src/main/java/net/creeperhost/polylib/chat/client/tab/TabPosition.java
+++ b/common/src/main/java/net/creeperhost/polylib/chat/client/tab/TabPosition.java
@@ -1,0 +1,7 @@
+package net.creeperhost.polylib.chat.client.tab;
+
+public enum TabPosition {
+    TOP,
+    SIDE_LEFT,
+    SIDE_RIGHT
+}

--- a/common/src/main/java/net/creeperhost/polylib/chat/client/tab/VanillaTab.java
+++ b/common/src/main/java/net/creeperhost/polylib/chat/client/tab/VanillaTab.java
@@ -1,0 +1,3 @@
+package net.creeperhost.polylib.chat.client.tab;
+
+public record VanillaTab() implements ChatTab {}

--- a/common/src/main/java/net/creeperhost/polylib/chat/layout/ChatLayoutManager.java
+++ b/common/src/main/java/net/creeperhost/polylib/chat/layout/ChatLayoutManager.java
@@ -1,0 +1,84 @@
+package net.creeperhost.polylib.chat.layout;
+
+import com.google.gson.*;
+import com.google.gson.reflect.TypeToken;
+import net.creeperhost.polylib.Constants;
+import net.minecraft.client.Minecraft;
+import net.minecraft.resources.Identifier;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Manages saving and loading of ChatWindowLayouts to the local client disk.
+ */
+public class ChatLayoutManager {
+    private static final Gson GSON = new GsonBuilder()
+            .setPrettyPrinting()
+            .registerTypeAdapter(Identifier.class, (JsonSerializer<Identifier>) (src, typeOfSrc, context) -> new JsonPrimitive(src.toString()))
+            .registerTypeAdapter(Identifier.class, (JsonDeserializer<Identifier>) (json, typeOfT, context) -> Identifier.parse(json.getAsString()))
+            .create();
+            
+    private final List<ChatWindowLayout> activeLayouts = new ArrayList<>();
+    private File layoutFile;
+
+    public ChatLayoutManager() {
+    }
+
+    public void init() {
+        if (Minecraft.getInstance() != null) {
+            File polyDir = new File(Minecraft.getInstance().gameDirectory, "config/polylib");
+            polyDir.mkdirs();
+            this.layoutFile = new File(polyDir, "chat_layouts.json");
+            load();
+        }
+    }
+
+    public List<ChatWindowLayout> getActiveLayouts() {
+        return activeLayouts;
+    }
+
+    public ChatWindowLayout getOrCreateLayout(String layoutId) {
+        for (ChatWindowLayout layout : activeLayouts) {
+            if (layout.getLayoutId().equals(layoutId)) {
+                return layout;
+            }
+        }
+        ChatWindowLayout newLayout = new ChatWindowLayout(layoutId, 10, 10, 200, 150);
+        activeLayouts.add(newLayout);
+        save();
+        return newLayout;
+    }
+
+    public void removeLayout(String layoutId) {
+        activeLayouts.removeIf(l -> l.getLayoutId().equals(layoutId));
+        save();
+    }
+
+    public void save() {
+        if (layoutFile == null) return;
+        try (FileWriter writer = new FileWriter(layoutFile)) {
+            GSON.toJson(activeLayouts, writer);
+        } catch (Exception e) {
+            Constants.LOG.error("Failed to save chat layouts", e);
+        }
+    }
+
+    public void load() {
+        if (layoutFile == null || !layoutFile.exists()) return;
+        try (FileReader reader = new FileReader(layoutFile)) {
+            Type listType = new TypeToken<ArrayList<ChatWindowLayout>>(){}.getType();
+            List<ChatWindowLayout> loaded = GSON.fromJson(reader, listType);
+            if (loaded != null) {
+                activeLayouts.clear();
+                activeLayouts.addAll(loaded);
+            }
+        } catch (Exception e) {
+            Constants.LOG.error("Failed to load chat layouts", e);
+        }
+    }
+}

--- a/common/src/main/java/net/creeperhost/polylib/chat/layout/ChatWindowLayout.java
+++ b/common/src/main/java/net/creeperhost/polylib/chat/layout/ChatWindowLayout.java
@@ -21,6 +21,10 @@ public class ChatWindowLayout {
     private boolean isPinned;
     private boolean isHidden;
     
+    private DisplayMode displayMode = DisplayMode.FLOATING;
+    private boolean minimized = false;
+    private SnapCorner snapCorner = null;  // null = free position
+
     // Which channels are docked in this window (for tabs)
     private final List<Identifier> tabbedChannels = new ArrayList<>();
     // Which tab is currently active/visible
@@ -86,6 +90,15 @@ public class ChatWindowLayout {
         isHidden = hidden;
     }
 
+    public DisplayMode getDisplayMode() { return displayMode; }
+    public void setDisplayMode(DisplayMode mode) { this.displayMode = mode; }
+
+    public boolean isMinimized() { return minimized; }
+    public void setMinimized(boolean minimized) { this.minimized = minimized; }
+
+    public SnapCorner getSnapCorner() { return snapCorner; }
+    public void setSnapCorner(SnapCorner snapCorner) { this.snapCorner = snapCorner; }
+
     public List<Identifier> getTabbedChannels() {
         return tabbedChannels;
     }
@@ -114,5 +127,11 @@ public class ChatWindowLayout {
         if (tabbedChannels.contains(activeTab)) {
             this.activeTab = activeTab;
         }
+    }
+
+    public enum DisplayMode {
+        FLOATING,
+        DOCKED_TOP,
+        DOCKED_SIDE
     }
 }

--- a/common/src/main/java/net/creeperhost/polylib/chat/layout/ChatWindowLayout.java
+++ b/common/src/main/java/net/creeperhost/polylib/chat/layout/ChatWindowLayout.java
@@ -1,0 +1,118 @@
+package net.creeperhost.polylib.chat.layout;
+
+import net.minecraft.resources.Identifier;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Represents the on-screen layout properties of a floating chat window.
+ * This state is persisted to disk.
+ */
+public class ChatWindowLayout {
+    private final String layoutId; // Could be a UUID or a custom string identifier for the window grouping
+    
+    // Position and dimensions (normalized or absolute screen coordinates)
+    private int x;
+    private int y;
+    private int width;
+    private int height;
+    
+    private boolean isPinned;
+    private boolean isHidden;
+    
+    // Which channels are docked in this window (for tabs)
+    private final List<Identifier> tabbedChannels = new ArrayList<>();
+    // Which tab is currently active/visible
+    private Identifier activeTab;
+
+    public ChatWindowLayout(String layoutId, int x, int y, int width, int height) {
+        this.layoutId = layoutId;
+        this.x = x;
+        this.y = y;
+        this.width = width;
+        this.height = height;
+    }
+
+    public String getLayoutId() {
+        return layoutId;
+    }
+
+    public int getX() {
+        return x;
+    }
+
+    public void setX(int x) {
+        this.x = x;
+    }
+
+    public int getY() {
+        return y;
+    }
+
+    public void setY(int y) {
+        this.y = y;
+    }
+
+    public int getWidth() {
+        return width;
+    }
+
+    public void setWidth(int width) {
+        this.width = width;
+    }
+
+    public int getHeight() {
+        return height;
+    }
+
+    public void setHeight(int height) {
+        this.height = height;
+    }
+
+    public boolean isPinned() {
+        return isPinned;
+    }
+
+    public void setPinned(boolean pinned) {
+        isPinned = pinned;
+    }
+
+    public boolean isHidden() {
+        return isHidden;
+    }
+
+    public void setHidden(boolean hidden) {
+        isHidden = hidden;
+    }
+
+    public List<Identifier> getTabbedChannels() {
+        return tabbedChannels;
+    }
+
+    public void addTab(Identifier channelId) {
+        if (!tabbedChannels.contains(channelId)) {
+            tabbedChannels.add(channelId);
+        }
+        if (activeTab == null) {
+            activeTab = channelId;
+        }
+    }
+
+    public void removeTab(Identifier channelId) {
+        tabbedChannels.remove(channelId);
+        if (activeTab != null && activeTab.equals(channelId)) {
+            activeTab = tabbedChannels.isEmpty() ? null : tabbedChannels.get(0);
+        }
+    }
+
+    public Identifier getActiveTab() {
+        return activeTab;
+    }
+
+    public void setActiveTab(Identifier activeTab) {
+        if (tabbedChannels.contains(activeTab)) {
+            this.activeTab = activeTab;
+        }
+    }
+}

--- a/common/src/main/java/net/creeperhost/polylib/chat/layout/SnapCorner.java
+++ b/common/src/main/java/net/creeperhost/polylib/chat/layout/SnapCorner.java
@@ -1,0 +1,39 @@
+package net.creeperhost.polylib.chat.layout;
+
+/**
+ * Screen corner a floating window is snapped to.
+ * When snapped, the window re-anchors on screen resize.
+ */
+public enum SnapCorner {
+    TOP_LEFT,
+    TOP_RIGHT,
+    BOTTOM_LEFT,
+    BOTTOM_RIGHT;
+
+    private static final int MARGIN = 4;
+
+    /**
+     * Compute the top-left position for a window of the given size, snapped to this corner.
+     * @return int[2] = {x, y}
+     */
+    public int[] computePosition(int windowWidth, int windowHeight, int screenWidth, int screenHeight) {
+        return switch (this) {
+            case TOP_LEFT     -> new int[]{ MARGIN, MARGIN };
+            case TOP_RIGHT    -> new int[]{ screenWidth - windowWidth - MARGIN, MARGIN };
+            case BOTTOM_LEFT  -> new int[]{ MARGIN, screenHeight - windowHeight - MARGIN };
+            case BOTTOM_RIGHT -> new int[]{ screenWidth - windowWidth - MARGIN, screenHeight - windowHeight - MARGIN };
+        };
+    }
+
+    /**
+     * Determine which corner (if any) a point is closest to, within threshold pixels.
+     * @return the closest SnapCorner, or null if none within threshold
+     */
+    public static SnapCorner detect(double centerX, double centerY, int screenWidth, int screenHeight, int threshold) {
+        if (centerX < threshold && centerY < threshold) return TOP_LEFT;
+        if (centerX > screenWidth - threshold && centerY < threshold) return TOP_RIGHT;
+        if (centerX < threshold && centerY > screenHeight - threshold) return BOTTOM_LEFT;
+        if (centerX > screenWidth - threshold && centerY > screenHeight - threshold) return BOTTOM_RIGHT;
+        return null;
+    }
+}

--- a/common/src/main/java/net/creeperhost/polylib/client/modulargui/elements/GuiButton.java
+++ b/common/src/main/java/net/creeperhost/polylib/client/modulargui/elements/GuiButton.java
@@ -309,6 +309,40 @@ public class GuiButton extends GuiElement<GuiButton> {
     }
 
     /**
+     * Creates a vanilla vertical tab with a "press" animation and rotated text.
+     */
+    public static GuiButton vanillaVerticalTab(@NotNull GuiParent<?> parent, Component label, Runnable onPress) {
+        return vanillaVerticalTab(parent, label == null ? null : () -> label).onPress(onPress);
+    }
+
+    /**
+     * Creates a vanilla vertical tab with a "press" animation and rotated text.
+     */
+    public static GuiButton vanillaVerticalTab(@NotNull GuiParent<?> parent, @Nullable Supplier<Component> label) {
+        GuiButton button = new GuiButton(parent);
+        GuiTexture texture = new GuiTexture(button, PolyTextures.getter(() -> button.toggleState() || button.isPressed() ? "dynamic/button_pressed" : "dynamic/button_vanilla"));
+        texture.dynamicTexture();
+        GuiRectangle highlight = new GuiRectangle(button).border(() -> button.isMouseOver() ? 0xFFFFFFFF : 0);
+
+        Constraints.bind(texture, button);
+        Constraints.bind(highlight, button);
+
+        if (label != null) {
+            GuiText text = new GuiText(button, label);
+            text.setRotation(-90.0D);
+            text.constrain(WIDTH, Constraint.dynamic(() -> (double) Minecraft.getInstance().font.width(label.get())));
+            text.constrain(HEIGHT, Constraint.literal(14));
+            
+            text.constrain(LEFT, Constraint.dynamic(() -> button.xMin() + (button.xSize() / 2) - (text.xSize() / 2) + (button.isPressed() ? 1 : 0)));
+            text.constrain(TOP, Constraint.dynamic(() -> button.yMin() + (button.ySize() / 2) - (text.ySize() / 2) + (button.isPressed() ? 1 : 0)));
+            
+            button.setLabel(text);
+        }
+
+        return button;
+    }
+
+    /**
      * Super simple button that is just a coloured rectangle with a label.
      */
     public static GuiButton flatColourButton(@NotNull GuiParent<?> parent, @Nullable Supplier<Component> label, Function<Boolean, Integer> buttonColour) {

--- a/common/src/main/java/net/creeperhost/polylib/client/modulargui/elements/GuiDropZone.java
+++ b/common/src/main/java/net/creeperhost/polylib/client/modulargui/elements/GuiDropZone.java
@@ -1,0 +1,29 @@
+package net.creeperhost.polylib.client.modulargui.elements;
+
+import net.creeperhost.polylib.client.modulargui.lib.geometry.GuiParent;
+
+/**
+ * A translucent highlight rectangle shown as a drop-zone indicator during drag operations.
+ * Starts hidden; call {@link #show()} / {@link #hide()} to toggle visibility.
+ */
+public class GuiDropZone extends GuiRectangle {
+
+    public GuiDropZone(GuiParent<?> parent) {
+        super(parent);
+        fill(0x4400AAFF);  // translucent blue
+        setEnabled(false); // hidden by default
+    }
+
+    public void show() {
+        setEnabled(true);
+    }
+
+    public void hide() {
+        setEnabled(false);
+    }
+
+    public GuiDropZone setHighlightColor(int argb) {
+        fill(argb);
+        return this;
+    }
+}

--- a/common/src/main/java/net/creeperhost/polylib/client/modulargui/elements/GuiManipulable.java
+++ b/common/src/main/java/net/creeperhost/polylib/client/modulargui/elements/GuiManipulable.java
@@ -440,6 +440,8 @@ public class GuiManipulable extends GuiElement<GuiManipulable> implements Conten
     //TODO, In v2 these were made available for elements that extend GuiManipulable, In v3 i probably just want to add listener hooks.
     protected void onManipulated(double mouseX, double mouseY) {}
 
+    protected boolean isDraggingPosition() { return isDragging && dragPos; }
+
     protected boolean onStartManipulation(double mouseX, double mouseY) {
         return false;
     }

--- a/common/src/main/java/net/creeperhost/polylib/client/modulargui/elements/GuiWindow.java
+++ b/common/src/main/java/net/creeperhost/polylib/client/modulargui/elements/GuiWindow.java
@@ -36,7 +36,8 @@ public class GuiWindow extends GuiManipulable {
 
         this.titleText = new GuiText(headerBar);
         this.titleText.constrain(GeoParam.LEFT, Constraint.relative(headerBar.get(GeoParam.LEFT), 4))
-                      .constrain(GeoParam.TOP, Constraint.relative(headerBar.get(GeoParam.TOP), 2))
+                      .constrain(GeoParam.TOP, Constraint.match(headerBar.get(GeoParam.TOP)))
+                      .constrain(GeoParam.BOTTOM, Constraint.match(headerBar.get(GeoParam.BOTTOM)))
                       .setShadow(true);
 
         this.closeButton = new GuiButton(headerBar);
@@ -44,9 +45,13 @@ public class GuiWindow extends GuiManipulable {
                         .constrain(GeoParam.TOP, Constraint.relative(headerBar.get(GeoParam.TOP), 2))
                         .constrain(GeoParam.WIDTH, Constraint.literal(10))
                         .constrain(GeoParam.HEIGHT, Constraint.literal(10));
+        // Right edge of title stops just before the close button
+        this.titleText.constrain(GeoParam.RIGHT, Constraint.relative(this.closeButton.get(GeoParam.LEFT), -2));
         GuiText closeLabel = new GuiText(this.closeButton, net.minecraft.network.chat.Component.literal("x"));
-        closeLabel.constrain(GeoParam.LEFT, Constraint.relative(this.closeButton.get(GeoParam.LEFT), 2))
-                  .constrain(GeoParam.TOP, Constraint.relative(this.closeButton.get(GeoParam.TOP), 0));
+        closeLabel.constrain(GeoParam.LEFT, Constraint.match(this.closeButton.get(GeoParam.LEFT)))
+                  .constrain(GeoParam.TOP, Constraint.match(this.closeButton.get(GeoParam.TOP)))
+                  .constrain(GeoParam.RIGHT, Constraint.match(this.closeButton.get(GeoParam.RIGHT)))
+                  .constrain(GeoParam.BOTTOM, Constraint.match(this.closeButton.get(GeoParam.BOTTOM)));
         this.closeButton.setLabel(closeLabel);
 
         // Use the header bar as the drag handle

--- a/common/src/main/java/net/creeperhost/polylib/client/modulargui/elements/GuiWindow.java
+++ b/common/src/main/java/net/creeperhost/polylib/client/modulargui/elements/GuiWindow.java
@@ -1,0 +1,74 @@
+package net.creeperhost.polylib.client.modulargui.elements;
+
+import net.creeperhost.polylib.client.modulargui.lib.geometry.Constraint;
+import net.creeperhost.polylib.client.modulargui.lib.geometry.GeoParam;
+import net.creeperhost.polylib.client.modulargui.lib.geometry.GuiParent;
+
+/**
+ * A draggable, floating window primitive built on GuiManipulable.
+ * Supports window titles, close buttons, and tab-group docking logic.
+ */
+public class GuiWindow extends GuiManipulable {
+
+    private final GuiRectangle headerBar;
+    private final GuiText titleText;
+    private final GuiButton closeButton;
+    private final GuiRectangle background;
+
+    public GuiWindow(GuiParent<?> parent) {
+        super(parent);
+        
+        // Background for the entire window
+        this.background = new GuiRectangle(getContentElement());
+        this.background.constrain(GeoParam.LEFT, Constraint.match(getContentElement().get(GeoParam.LEFT)))
+                       .constrain(GeoParam.RIGHT, Constraint.match(getContentElement().get(GeoParam.RIGHT)))
+                       .constrain(GeoParam.TOP, Constraint.match(getContentElement().get(GeoParam.TOP)))
+                       .constrain(GeoParam.BOTTOM, Constraint.match(getContentElement().get(GeoParam.BOTTOM)))
+                       .fill(0xDD202020);
+
+        // Header bar (used for dragging)
+        this.headerBar = new GuiRectangle(getContentElement());
+        this.headerBar.constrain(GeoParam.LEFT, Constraint.match(getContentElement().get(GeoParam.LEFT)))
+                      .constrain(GeoParam.RIGHT, Constraint.match(getContentElement().get(GeoParam.RIGHT)))
+                      .constrain(GeoParam.TOP, Constraint.match(getContentElement().get(GeoParam.TOP)))
+                      .constrain(GeoParam.HEIGHT, Constraint.literal(14))
+                      .fill(0xFF333333);
+
+        this.titleText = new GuiText(headerBar);
+        this.titleText.constrain(GeoParam.LEFT, Constraint.relative(headerBar.get(GeoParam.LEFT), 4))
+                      .constrain(GeoParam.TOP, Constraint.relative(headerBar.get(GeoParam.TOP), 2))
+                      .setShadow(true);
+
+        this.closeButton = new GuiButton(headerBar);
+        this.closeButton.constrain(GeoParam.RIGHT, Constraint.relative(headerBar.get(GeoParam.RIGHT), -2))
+                        .constrain(GeoParam.TOP, Constraint.relative(headerBar.get(GeoParam.TOP), 2))
+                        .constrain(GeoParam.WIDTH, Constraint.literal(10))
+                        .constrain(GeoParam.HEIGHT, Constraint.literal(10));
+        GuiText closeLabel = new GuiText(this.closeButton, net.minecraft.network.chat.Component.literal("x"));
+        closeLabel.constrain(GeoParam.LEFT, Constraint.relative(this.closeButton.get(GeoParam.LEFT), 2))
+                  .constrain(GeoParam.TOP, Constraint.relative(this.closeButton.get(GeoParam.TOP), 0));
+        this.closeButton.setLabel(closeLabel);
+
+        // Use the header bar as the drag handle
+        this.setMoveHandle(headerBar);
+        this.addResizeHandles(4, false); // Bottom, Left, Right resizing
+        this.enableCursors(true);
+    }
+
+    public GuiWindow setTitle(net.minecraft.network.chat.Component title) {
+        this.titleText.setText(title);
+        return this;
+    }
+
+    public GuiButton getCloseButton() {
+        return closeButton;
+    }
+
+    public GuiRectangle getBackground() {
+        return background;
+    }
+
+    public GuiRectangle getHeaderBar() {
+        return headerBar;
+    }
+}

--- a/fabric/src/main/java/net/creeperhost/polylib/PolyLibClientFabric.java
+++ b/fabric/src/main/java/net/creeperhost/polylib/PolyLibClientFabric.java
@@ -56,9 +56,15 @@ public class PolyLibClientFabric
             PolyScreenEvents.SCREEN_OPENED.invoker().onScreenOpened(mc, screen, w, h);
             
             ScreenEvents.remove(screen).register(s -> PolyScreenEvents.SCREEN_CLOSING.invoker().onScreenClosing(s));
-            
+
             ScreenEvents.beforeTick(screen).register(s -> PolyScreenEvents.SCREEN_TICK_BEFORE.invoker().onScreenTickBefore(s));
             ScreenEvents.afterTick(screen).register(s -> PolyScreenEvents.SCREEN_TICK_AFTER.invoker().onScreenTickAfter(s));
+
+            // Screen render events — required by ModularGuiInjector to draw injected GUIs
+            ScreenEvents.beforeExtract(screen).register((s, gg, mx, my, pt) ->
+                    PolyScreenEvents.SCREEN_RENDER_PRE.invoker().onScreenRenderPre(s, gg, mx, my, pt));
+            ScreenEvents.afterExtract(screen).register((s, gg, mx, my, pt) ->
+                    PolyScreenEvents.SCREEN_RENDER_POST.invoker().onScreenRenderPost(s, gg, mx, my, pt));
 
             // Keyboard
             ScreenKeyboardEvents.allowKeyPress(screen).register((s, ke) -> {

--- a/fabric/src/main/java/net/creeperhost/polylib/mixin/client/FabricChatComponentMixin.java
+++ b/fabric/src/main/java/net/creeperhost/polylib/mixin/client/FabricChatComponentMixin.java
@@ -1,0 +1,27 @@
+package net.creeperhost.polylib.mixin.client;
+
+import net.creeperhost.polylib.chat.client.tab.ChatTabRegistry;
+import net.creeperhost.polylib.chat.client.tab.VanillaTab;
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+import net.minecraft.client.gui.components.ChatComponent;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(ChatComponent.class)
+public class FabricChatComponentMixin {
+
+    @Inject(method = "extractRenderState(Lnet/minecraft/client/gui/GuiGraphicsExtractor;Lnet/minecraft/client/gui/Font;IIILnet/minecraft/client/gui/components/ChatComponent$DisplayMode;Z)V",
+            at = @At("HEAD"), cancellable = true)
+    private void polylib$suppressVanillaChatRender(
+            GuiGraphicsExtractor graphics, Font font, int ticks, int mouseX, int mouseY,
+            ChatComponent.DisplayMode displayMode, boolean changeCursor,
+            CallbackInfo ci) {
+        ChatTabRegistry reg = ChatTabRegistry.get();
+        if (reg.hasAnyChannel() && !(reg.getActiveTab() instanceof VanillaTab)) {
+            ci.cancel();
+        }
+    }
+}

--- a/fabric/src/main/java/net/creeperhost/polylib/mixin/client/FabricChatScreenMixin.java
+++ b/fabric/src/main/java/net/creeperhost/polylib/mixin/client/FabricChatScreenMixin.java
@@ -1,0 +1,34 @@
+package net.creeperhost.polylib.mixin.client;
+
+import net.creeperhost.polylib.chat.client.tab.*;
+import net.minecraft.client.gui.screens.ChatScreen;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(ChatScreen.class)
+public class FabricChatScreenMixin {
+
+    @Inject(method = "handleChatInput", at = @At("HEAD"), cancellable = true)
+    private void polylib$redirectChatInput(String msg, boolean addToRecent, CallbackInfo ci) {
+        ChatTabRegistry reg = ChatTabRegistry.get();
+        if (!reg.hasAnyChannel()) return;
+
+        ChatTab active = reg.getActiveTab();
+        switch (active) {
+            case VanillaTab v -> {} // let vanilla handle it
+            case AllTab a -> {
+                for (var entry : reg.allEntries()) {
+                    entry.channel().submitMessage(msg);
+                }
+                // Don't cancel — let vanilla sendChat/sendCommand proceed too
+            }
+            case ChannelTab ct -> {
+                ct.channel().submitMessage(msg);
+                ci.cancel();
+            }
+            case NotificationTab nt -> ci.cancel(); // notifications are read-only
+        }
+    }
+}

--- a/fabric/src/main/resources/polylib.fabric.mixins.json
+++ b/fabric/src/main/resources/polylib.fabric.mixins.json
@@ -102,7 +102,9 @@
     "client.MixinScreenCharTypedFabric",
     "client.MixinAbstractContainerScreenFabric",
     "client.FabricDebugEntriesMixin",
-    "client.EntryMapAccessor"
+    "client.EntryMapAccessor",
+    "client.FabricChatComponentMixin",
+    "client.FabricChatScreenMixin"
   ],
   "server": [],
   "injectors": {

--- a/neoforge/src/main/java/net/creeperhost/polylib/mixin/MixinChatComponentNF.java
+++ b/neoforge/src/main/java/net/creeperhost/polylib/mixin/MixinChatComponentNF.java
@@ -1,0 +1,27 @@
+package net.creeperhost.polylib.mixin;
+
+import net.creeperhost.polylib.chat.client.tab.ChatTabRegistry;
+import net.creeperhost.polylib.chat.client.tab.VanillaTab;
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+import net.minecraft.client.gui.components.ChatComponent;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(ChatComponent.class)
+public class MixinChatComponentNF {
+
+    @Inject(method = "extractRenderState(Lnet/minecraft/client/gui/GuiGraphicsExtractor;Lnet/minecraft/client/gui/Font;IIILnet/minecraft/client/gui/components/ChatComponent$DisplayMode;Z)V",
+            at = @At("HEAD"), cancellable = true)
+    private void polylib$suppressVanillaChatRender(
+            GuiGraphicsExtractor graphics, Font font, int ticks, int mouseX, int mouseY,
+            ChatComponent.DisplayMode displayMode, boolean changeCursor,
+            CallbackInfo ci) {
+        ChatTabRegistry reg = ChatTabRegistry.get();
+        if (reg.hasAnyChannel() && !(reg.getActiveTab() instanceof VanillaTab)) {
+            ci.cancel();
+        }
+    }
+}

--- a/neoforge/src/main/java/net/creeperhost/polylib/mixin/MixinChatScreenNF.java
+++ b/neoforge/src/main/java/net/creeperhost/polylib/mixin/MixinChatScreenNF.java
@@ -1,0 +1,33 @@
+package net.creeperhost.polylib.mixin;
+
+import net.creeperhost.polylib.chat.client.tab.*;
+import net.minecraft.client.gui.screens.ChatScreen;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(ChatScreen.class)
+public class MixinChatScreenNF {
+
+    @Inject(method = "handleChatInput", at = @At("HEAD"), cancellable = true)
+    private void polylib$redirectChatInput(String msg, boolean addToRecent, CallbackInfo ci) {
+        ChatTabRegistry reg = ChatTabRegistry.get();
+        if (!reg.hasAnyChannel()) return;
+
+        ChatTab active = reg.getActiveTab();
+        switch (active) {
+            case VanillaTab v -> {}
+            case AllTab a -> {
+                for (var entry : reg.allEntries()) {
+                    entry.channel().submitMessage(msg);
+                }
+            }
+            case ChannelTab ct -> {
+                ct.channel().submitMessage(msg);
+                ci.cancel();
+            }
+            case NotificationTab nt -> ci.cancel(); // notifications are read-only
+        }
+    }
+}

--- a/neoforge/src/main/resources/polylib.neoforge.mixins.json
+++ b/neoforge/src/main/resources/polylib.neoforge.mixins.json
@@ -23,7 +23,9 @@
     "MixinMinecraftSetLevelNF",
     "MixinLevelRendererBlockOutlineNF",
     "MixinLevelRendererAllChangedNF",
-    "MixinCapeLayerNF"
+    "MixinCapeLayerNF",
+    "MixinChatComponentNF",
+    "MixinChatScreenNF"
   ],
   "server": [],
   "injectors": {

--- a/settings.gradle
+++ b/settings.gradle
@@ -27,7 +27,7 @@ include('common')
 include('fabric')
 include('neoforge')
 
-include('testmod-common')
-include('testmod-fabric')
-include('testmod-neoforge')
+// // include('testmod-common')
+// include('testmod-fabric')
+// include('testmod-neoforge')
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -27,7 +27,7 @@ include('common')
 include('fabric')
 include('neoforge')
 
-//include('testmod-common')
-//include('testmod-fabric')
-//include('testmod-neoforge')
+include('testmod-common')
+include('testmod-fabric')
+include('testmod-neoforge')
 

--- a/testmod-common/src/main/java/net/creeperhost/testmod/TestModClientCommon.java
+++ b/testmod-common/src/main/java/net/creeperhost/testmod/TestModClientCommon.java
@@ -4,7 +4,12 @@ import net.creeperhost.polylib.chat.ChatChannel;
 import net.creeperhost.polylib.chat.ChatMember;
 import net.creeperhost.polylib.chat.ChatRouter;
 import net.creeperhost.polylib.chat.RichChatMessage;
+import net.creeperhost.polylib.chat.client.ChatNotifications;
 import net.creeperhost.polylib.chat.client.FloatingChatWindow;
+import net.creeperhost.polylib.chat.client.notification.NotificationEntry;
+import net.creeperhost.polylib.chat.client.notification.NotificationSeverity;
+import net.creeperhost.polylib.chat.client.notification.PolyNotifications;
+import net.creeperhost.polylib.chat.client.tab.ChatTabRegistry;
 import net.creeperhost.polylib.client.modulargui.ModularGuiInjector;
 import net.creeperhost.polylib.client.modulargui.ModularGuiScreen;
 import net.creeperhost.polylib.client.modulargui.lib.geometry.Constraint;
@@ -23,6 +28,12 @@ import static net.creeperhost.testmod.TestModCommon.LOGGER;
 
 public class TestModClientCommon
 {
+    // --- Channel IDs ---
+    static final Identifier CH_GENERAL  = Identifier.fromNamespaceAndPath("testmod", "general");
+    static final Identifier CH_GUILD    = Identifier.fromNamespaceAndPath("testmod", "guild");
+    static final Identifier CH_SYSTEM   = Identifier.fromNamespaceAndPath("testmod", "system");
+    static final Identifier CH_TRADE    = Identifier.fromNamespaceAndPath("testmod", "trade");
+
     public static void init()
     {
         TestClientEvents.init();
@@ -30,55 +41,186 @@ public class TestModClientCommon
         TestDebugEntries.init();
         ModularGuiInjector.registerInjection(e -> e instanceof TitleScreen, e -> new MainMenuGuiInjection());
 
-        // Register a test chat channel
-        Identifier testChannelId = Identifier.fromNamespaceAndPath("testmod", "test_channel");
-        ChatChannel testChannel = new ChatChannel(testChannelId, Component.literal("Test Channel"), true);
-        ChatRouter.getInstance().registerChannel(testChannel);
+        // -----------------------------------------------------------------------
+        // 1. Register chat channels
+        // -----------------------------------------------------------------------
 
-        // Add some dummy members and messages
-        testChannel.addMember(new ChatMember(UUID.randomUUID(), Component.literal("Test User"), null, true));
-        testChannel.addMessage(RichChatMessage.create(Component.literal("Welcome to the test channel!"), Component.literal("System")));
-        testChannel.addMessage(RichChatMessage.create(Component.literal("This is a draggable modular window."), Component.literal("System")));
+        // General — TOP tab, player can submit messages (loopback echo)
+        ChatChannel general = new ChatChannel(CH_GENERAL, Component.literal("General"), true);
+        general.setSubmitHandler(text -> {
+            Minecraft mc2 = Minecraft.getInstance();
+            String sender = mc2.player != null ? mc2.player.getScoreboardName() : "Player";
+            general.addMessage(RichChatMessage.create(Component.literal(text), Component.literal(sender)));
+        });
+        general.addMember(new ChatMember(UUID.randomUUID(), Component.literal("Steve"), null, true));
+        general.addMember(new ChatMember(UUID.randomUUID(), Component.literal("Alex"), null, false));
+        general.addMessage(RichChatMessage.create(Component.literal("Welcome to the General channel!"), Component.literal("Server")));
+        general.addMessage(RichChatMessage.create(Component.literal("Type something in chat to try submitting a message."), Component.literal("Server")));
+        ChatRouter.getInstance().registerChannel(general);
+        ChatTabRegistry.get().registerTop(general);
 
-        // KP_5 (Numpad 5) — open a FloatingChatWindow for every registered channel
+        // Guild — TOP tab, second channel for switching/pulse test
+        ChatChannel guild = new ChatChannel(CH_GUILD, Component.literal("Guild"), false);
+        guild.setSubmitHandler(text -> {
+            Minecraft mc2 = Minecraft.getInstance();
+            String sender = mc2.player != null ? mc2.player.getScoreboardName() : "Player";
+            guild.addMessage(RichChatMessage.create(Component.literal(text), Component.literal(sender)));
+        });
+        guild.addMessage(RichChatMessage.create(Component.literal("Guild HQ reporting in."), Component.literal("Guildmaster")));
+        guild.addMessage(RichChatMessage.create(Component.literal("Use KP_6 to trigger a mention pulse on this channel."), Component.literal("Server")));
+        ChatRouter.getInstance().registerChannel(guild);
+        ChatTabRegistry.get().registerTop(guild);
+
+        // System — SIDE_LEFT tab — read-only server alerts
+        ChatChannel system = new ChatChannel(CH_SYSTEM, Component.literal("Sys"), false);
+        system.addMessage(RichChatMessage.create(Component.literal("[INFO] Server started successfully."), Component.literal("System")));
+        system.addMessage(RichChatMessage.create(Component.literal("[WARN] TPS dropped to 15 for 2 seconds."), Component.literal("System")));
+        system.addMessage(RichChatMessage.create(Component.literal("[INFO] 3 players online."), Component.literal("System")));
+        ChatRouter.getInstance().registerChannel(system);
+        ChatTabRegistry.get().registerSideLeft(system);
+
+        // Trade — SIDE_RIGHT tab — economy/trade chat
+        ChatChannel trade = new ChatChannel(CH_TRADE, Component.literal("Trade"), false);
+        trade.setSubmitHandler(text -> {
+            Minecraft mc2 = Minecraft.getInstance();
+            String sender = mc2.player != null ? mc2.player.getScoreboardName() : "Player";
+            trade.addMessage(RichChatMessage.create(Component.literal(text), Component.literal(sender)));
+        });
+        trade.addMessage(RichChatMessage.create(Component.literal("WTS 64x Diamond — 50g each, /msg Steve"), Component.literal("Steve")));
+        trade.addMessage(RichChatMessage.create(Component.literal("WTB Iron Ingots in bulk — DM me"), Component.literal("Alex")));
+        ChatRouter.getInstance().registerChannel(trade);
+        ChatTabRegistry.get().registerSideRight(trade);
+
+        // -----------------------------------------------------------------------
+        // 2. Register shared notifications window as a TOP tab (Plan D)
+        // -----------------------------------------------------------------------
+        PolyNotifications.init(); // ensure the shared window exists
+        ChatTabRegistry.get().registerNotificationTop(
+            PolyNotifications.SHARED_WINDOW_ID,
+            Component.literal("Notifs")
+        );
+
+        // -----------------------------------------------------------------------
+        // 3. Mention pulse: register TRIGGER_ANY_MESSAGE on the System channel
+        //    so every system message pulses the side-left tab
+        // -----------------------------------------------------------------------
+        ChatNotifications.registerMentionTrigger(CH_SYSTEM, ChatNotifications.TRIGGER_ANY_MESSAGE);
+
+        // -----------------------------------------------------------------------
+        // 4. Keybinds (all fire on key-press only, outside any open screen)
+        // -----------------------------------------------------------------------
         PolyInputEvents.INPUT_KEY.register((key, scanCode, action, modifiers) ->
         {
             if (action != 1) return; // press only
             Minecraft mc = Minecraft.getInstance();
             if (mc.screen != null) return;
+
+            // ------------------------------------------------------------------
+            // KP_5 — open all channels as floating windows (Plan B test)
+            // ------------------------------------------------------------------
             if (key == GLFW.GLFW_KEY_KP_5)
             {
-                java.util.Collection<ChatChannel> channels = ChatRouter.getInstance().getActiveChannels();
-                if (channels.isEmpty())
-                {
-                    LOGGER.warn("[TestMod] KP_5: no channels registered");
-                    return;
-                }
-                LOGGER.info("[TestMod] KP_5: opening FloatingChatWindow for {} channel(s)", channels.size());
+                LOGGER.info("[TestMod] KP_5: opening FloatingChatWindow for all channels");
                 mc.setScreen(new ModularGuiScreen(gui ->
                 {
                     gui.initFullscreenGui();
                     int offset = 0;
-                    for (ChatChannel ch : channels)
+                    for (ChatChannel ch : ChatRouter.getInstance().getActiveChannels())
                     {
-                        // Wire up a local loopback submit handler if none is set
-                        ch.setSubmitHandler(text ->
-                        {
-                            Minecraft mc2 = Minecraft.getInstance();
-                            String senderName = mc2.player != null ? mc2.player.getScoreboardName() : "Player";
-                            ch.addMessage(RichChatMessage.create(
-                                    net.minecraft.network.chat.Component.literal(text),
-                                    net.minecraft.network.chat.Component.literal(senderName)));
-                        });
                         FloatingChatWindow win = new FloatingChatWindow(gui.getRoot(), ch);
-                        win.constrain(GeoParam.LEFT,   Constraint.literal(40 + offset * 20))
-                           .constrain(GeoParam.TOP,    Constraint.literal(40 + offset * 20))
+                        win.constrain(GeoParam.LEFT,   Constraint.literal(40 + offset * 25))
+                           .constrain(GeoParam.TOP,    Constraint.literal(40 + offset * 25))
                            .constrain(GeoParam.WIDTH,  Constraint.literal(280))
                            .constrain(GeoParam.HEIGHT, Constraint.literal(200));
                         offset++;
                     }
                 }));
             }
+
+            // ------------------------------------------------------------------
+            // KP_6 — simulate a mention in Guild to trigger pulse (Plan C test)
+            // ------------------------------------------------------------------
+            if (key == GLFW.GLFW_KEY_KP_6)
+            {
+                String playerName = mc.player != null ? mc.player.getScoreboardName() : "Player";
+                LOGGER.info("[TestMod] KP_6: simulating mention of '{}' in Guild", playerName);
+                guild.addMessage(RichChatMessage.create(
+                    Component.literal("Hey " + playerName + "! You got a mention."),
+                    Component.literal("Alex")
+                ));
+                // Also pulse System channel with a new alert
+                system.addMessage(RichChatMessage.create(
+                    Component.literal("[ALERT] Player " + playerName + " triggered KP_6 test"),
+                    Component.literal("System")
+                ));
+            }
+
+            // ------------------------------------------------------------------
+            // KP_7 — send test notifications (Plan D test)
+            // ------------------------------------------------------------------
+            if (key == GLFW.GLFW_KEY_KP_7)
+            {
+                Identifier src = Identifier.fromNamespaceAndPath("testmod", "test");
+                PolyNotifications.send(NotificationEntry.create(
+                    src,
+                    Component.literal("Server Info"),
+                    Component.literal("3 players are online right now."),
+                    NotificationSeverity.INFO
+                ));
+                PolyNotifications.send(NotificationEntry.create(
+                    src,
+                    Component.literal("Low Resources"),
+                    Component.literal("Server TPS is below 18. Expect lag."),
+                    NotificationSeverity.WARNING
+                ));
+                PolyNotifications.send(NotificationEntry.create(
+                    src,
+                    Component.literal("PVP Alert"),
+                    Component.literal("A hostile player is nearby!"),
+                    NotificationSeverity.ALERT
+                ));
+                LOGGER.info("[TestMod] KP_7: sent INFO + WARNING + ALERT notifications (check 'Notifs' tab)");
+            }
+
+            // ------------------------------------------------------------------
+            // KP_8 — flood all channels with rapid messages (stress test)
+            // ------------------------------------------------------------------
+            if (key == GLFW.GLFW_KEY_KP_8)
+            {
+                LOGGER.info("[TestMod] KP_8: flooding all channels with 10 messages each");
+                for (int i = 1; i <= 10; i++)
+                {
+                    general.addMessage(RichChatMessage.create(Component.literal("Flood message #" + i), Component.literal("Bot")));
+                    guild.addMessage(RichChatMessage.create(Component.literal("Guild flood #" + i), Component.literal("GuildBot")));
+                    system.addMessage(RichChatMessage.create(Component.literal("[INFO] System message #" + i), Component.literal("System")));
+                    trade.addMessage(RichChatMessage.create(Component.literal("WTS Item #" + i + " — DM me"), Component.literal("Trader")));
+                }
+            }
+
+            // ------------------------------------------------------------------
+            // KP_9 — send one of each notification severity to verify badges
+            // ------------------------------------------------------------------
+            if (key == GLFW.GLFW_KEY_KP_9)
+            {
+                Identifier src = Identifier.fromNamespaceAndPath("testmod", "badge_test");
+                for (NotificationSeverity sev : NotificationSeverity.values())
+                {
+                    PolyNotifications.send(NotificationEntry.create(
+                        src,
+                        Component.literal(sev.name() + " Badge Test"),
+                        Component.literal("Testing unread badge counter for " + sev.name()),
+                        sev
+                    ));
+                }
+                LOGGER.info("[TestMod] KP_9: sent badge test notifications (3 unread — check tab badge count)");
+            }
         });
+
+        LOGGER.info("[TestMod] Chat system test channels registered:");
+        LOGGER.info("  TOP  tabs : General, Guild, Notifs");
+        LOGGER.info("  LEFT tab  : Sys  (side-left bar)");
+        LOGGER.info("  RIGHT tab : Trade (side-right bar)");
+        LOGGER.info("  KP_5 = open floating windows | KP_6 = trigger mention pulse");
+        LOGGER.info("  KP_7 = send 3 notifications  | KP_8 = flood messages | KP_9 = badge test");
     }
 }

--- a/testmod-common/src/main/java/net/creeperhost/testmod/TestModClientCommon.java
+++ b/testmod-common/src/main/java/net/creeperhost/testmod/TestModClientCommon.java
@@ -1,10 +1,25 @@
 package net.creeperhost.testmod;
 
+import net.creeperhost.polylib.chat.ChatChannel;
+import net.creeperhost.polylib.chat.ChatMember;
+import net.creeperhost.polylib.chat.ChatRouter;
+import net.creeperhost.polylib.chat.RichChatMessage;
+import net.creeperhost.polylib.chat.client.FloatingChatWindow;
 import net.creeperhost.polylib.client.modulargui.ModularGuiInjector;
+import net.creeperhost.polylib.client.modulargui.ModularGuiScreen;
+import net.creeperhost.polylib.client.modulargui.lib.geometry.Constraint;
+import net.creeperhost.polylib.client.modulargui.lib.geometry.GeoParam;
+import net.creeperhost.polylib.event.events.client.PolyInputEvents;
 import net.creeperhost.testmod.init.TestClientEvents;
 import net.creeperhost.testmod.init.TestDebugEntries;
 import net.creeperhost.testmod.init.TestScreens;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.TitleScreen;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.Identifier;
+import org.lwjgl.glfw.GLFW;
+import java.util.UUID;
+import static net.creeperhost.testmod.TestModCommon.LOGGER;
 
 public class TestModClientCommon
 {
@@ -14,5 +29,56 @@ public class TestModClientCommon
         TestScreens.init();
         TestDebugEntries.init();
         ModularGuiInjector.registerInjection(e -> e instanceof TitleScreen, e -> new MainMenuGuiInjection());
+
+        // Register a test chat channel
+        Identifier testChannelId = Identifier.fromNamespaceAndPath("testmod", "test_channel");
+        ChatChannel testChannel = new ChatChannel(testChannelId, Component.literal("Test Channel"), true);
+        ChatRouter.getInstance().registerChannel(testChannel);
+
+        // Add some dummy members and messages
+        testChannel.addMember(new ChatMember(UUID.randomUUID(), Component.literal("Test User"), null, true));
+        testChannel.addMessage(RichChatMessage.create(Component.literal("Welcome to the test channel!"), Component.literal("System")));
+        testChannel.addMessage(RichChatMessage.create(Component.literal("This is a draggable modular window."), Component.literal("System")));
+
+        // KP_5 (Numpad 5) — open a FloatingChatWindow for every registered channel
+        PolyInputEvents.INPUT_KEY.register((key, scanCode, action, modifiers) ->
+        {
+            if (action != 1) return; // press only
+            Minecraft mc = Minecraft.getInstance();
+            if (mc.screen != null) return;
+            if (key == GLFW.GLFW_KEY_KP_5)
+            {
+                java.util.Collection<ChatChannel> channels = ChatRouter.getInstance().getActiveChannels();
+                if (channels.isEmpty())
+                {
+                    LOGGER.warn("[TestMod] KP_5: no channels registered");
+                    return;
+                }
+                LOGGER.info("[TestMod] KP_5: opening FloatingChatWindow for {} channel(s)", channels.size());
+                mc.setScreen(new ModularGuiScreen(gui ->
+                {
+                    gui.initFullscreenGui();
+                    int offset = 0;
+                    for (ChatChannel ch : channels)
+                    {
+                        // Wire up a local loopback submit handler if none is set
+                        ch.setSubmitHandler(text ->
+                        {
+                            Minecraft mc2 = Minecraft.getInstance();
+                            String senderName = mc2.player != null ? mc2.player.getScoreboardName() : "Player";
+                            ch.addMessage(RichChatMessage.create(
+                                    net.minecraft.network.chat.Component.literal(text),
+                                    net.minecraft.network.chat.Component.literal(senderName)));
+                        });
+                        FloatingChatWindow win = new FloatingChatWindow(gui.getRoot(), ch);
+                        win.constrain(GeoParam.LEFT,   Constraint.literal(40 + offset * 20))
+                           .constrain(GeoParam.TOP,    Constraint.literal(40 + offset * 20))
+                           .constrain(GeoParam.WIDTH,  Constraint.literal(280))
+                           .constrain(GeoParam.HEIGHT, Constraint.literal(200));
+                        offset++;
+                    }
+                }));
+            }
+        });
     }
 }

--- a/testmod-common/src/main/java/net/creeperhost/testmod/init/TestClientEvents.java
+++ b/testmod-common/src/main/java/net/creeperhost/testmod/init/TestClientEvents.java
@@ -1,5 +1,9 @@
 package net.creeperhost.testmod.init;
 
+import net.creeperhost.polylib.chat.ChatChannel;
+import net.creeperhost.polylib.chat.ChatRouter;
+import net.creeperhost.polylib.chat.client.FloatingChatWindow;
+import net.creeperhost.polylib.client.modulargui.ModularGuiScreen;
 import net.creeperhost.polylib.event.events.client.PolyCameraEvents;
 import net.creeperhost.polylib.event.events.client.PolyClientBlockEntityEvents;
 import net.creeperhost.polylib.event.events.client.PolyClientChunkEvents;
@@ -16,6 +20,9 @@ import net.creeperhost.polylib.event.events.client.PolyRenderEvents;
 import net.creeperhost.polylib.event.events.client.PolyRenderStateEvents;
 import net.creeperhost.polylib.event.events.client.PolyTooltipEvents;
 import net.creeperhost.polylib.event.events.server.PolyRegistryEvents;
+import net.minecraft.client.Minecraft;
+import net.minecraft.resources.Identifier;
+import org.lwjgl.glfw.GLFW;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;

--- a/testmod-common/src/main/java/net/creeperhost/testmod/init/TestCommands.java
+++ b/testmod-common/src/main/java/net/creeperhost/testmod/init/TestCommands.java
@@ -4,6 +4,10 @@ import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.arguments.IntegerArgumentType;
 import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.context.CommandContext;
+import net.creeperhost.polylib.chat.ChatChannel;
+import net.creeperhost.polylib.chat.ChatMember;
+import net.creeperhost.polylib.chat.ChatRouter;
+import net.creeperhost.polylib.chat.RichChatMessage;
 import net.creeperhost.polylib.event.events.server.PolyServerCommandEvents;
 import net.creeperhost.polylib.platform.Services;
 import net.creeperhost.polylib.player.serverdata.PlayerServerDataManager;
@@ -17,10 +21,11 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.resources.Identifier;
 import net.minecraft.server.level.ServerLevel;
-import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.MenuProvider;
 import net.minecraft.world.SimpleMenuProvider;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.effect.MobEffects;
@@ -111,6 +116,19 @@ public final class TestCommands
                                 .executes(TestCommands::testOfflineData)))
                 // player inventory mirror test
                 .then(Commands.literal("mirror").executes(TestCommands::testMirror))
+                // chat system test commands
+                .then(Commands.literal("chat")
+                        .then(Commands.literal("list").executes(TestCommands::testChatList))
+                        .then(Commands.literal("join")
+                                .then(Commands.argument("channel", StringArgumentType.word())
+                                        .executes(TestCommands::testChatJoin)))
+                        .then(Commands.literal("leave")
+                                .then(Commands.argument("channel", StringArgumentType.word())
+                                        .executes(TestCommands::testChatLeave)))
+                        .then(Commands.literal("say")
+                                .then(Commands.argument("channel", StringArgumentType.word())
+                                        .then(Commands.argument("message", StringArgumentType.greedyString())
+                                                .executes(TestCommands::testChatSay)))))
         );
     }
 
@@ -979,6 +997,7 @@ public final class TestCommands
         src.sendSuccess(() -> Component.literal("  §fInfo: §7passive (auto-firing events), manual (gameplay-required events), help"), false);
         src.sendSuccess(() -> Component.literal("  §fOffline: §7offlinedata set <n>  |  offlinedata <name|uuid>"), false);
         src.sendSuccess(() -> Component.literal("  §fMirror: §7mirror"), false);
+        src.sendSuccess(() -> Component.literal("  §fChat: §7chat list/join/leave/say — press KP_5 to open window"), false);
         return 1;
     }
 
@@ -1004,6 +1023,117 @@ public final class TestCommands
         catch (Exception e)
         {
             src.sendFailure(Component.literal("[polytest] mirror: " + e.getMessage()));
+        }
+        return 1;
+    }
+
+    // =========================================================================
+    // Chat System
+    // =========================================================================
+
+    // ----- /polytest chat list -----
+    private static int testChatList(CommandContext<CommandSourceStack> ctx)
+    {
+        CommandSourceStack src = ctx.getSource();
+        java.util.Collection<ChatChannel> channels = ChatRouter.getInstance().getActiveChannels();
+        src.sendSuccess(() -> Component.literal("[polytest] chat: " + channels.size() + " channel(s) registered:"), false);
+        if (channels.isEmpty())
+        {
+            src.sendSuccess(() -> Component.literal("  (none — use /polytest chat join <channel> to create one)"), false);
+        }
+        for (ChatChannel ch : channels)
+        {
+            src.sendSuccess(() -> Component.literal("  - " + ch.getChannelId() + " (" + ch.getMembers().size() + " members)"), false);
+        }
+        return 1;
+    }
+
+    // ----- /polytest chat join <channel> -----
+    private static int testChatJoin(CommandContext<CommandSourceStack> ctx)
+    {
+        CommandSourceStack src = ctx.getSource();
+        try
+        {
+            String channelName = StringArgumentType.getString(ctx, "channel");
+            Identifier id = Identifier.fromNamespaceAndPath("testmod", channelName);
+            ServerPlayer player = src.getPlayerOrException();
+
+            ChatChannel ch = ChatRouter.getInstance().getChannel(id);
+            if (ch == null)
+            {
+                ch = new ChatChannel(id, Component.literal(channelName), true);
+                ChatRouter.getInstance().registerChannel(ch);
+                src.sendSuccess(() -> Component.literal("[polytest] chat join: created channel " + id), false);
+            }
+            ch.addMember(new ChatMember(player.getUUID(), player.getDisplayName(), null, true));
+            final ChatChannel finalCh = ch;
+            src.sendSuccess(() -> Component.literal("[polytest] chat join: " + player.getScoreboardName() + " joined " + finalCh.getChannelId()), false);
+        }
+        catch (Exception e)
+        {
+            src.sendFailure(Component.literal("[polytest] chat join: " + e.getMessage()));
+        }
+        return 1;
+    }
+
+    // ----- /polytest chat leave <channel> -----
+    private static int testChatLeave(CommandContext<CommandSourceStack> ctx)
+    {
+        CommandSourceStack src = ctx.getSource();
+        try
+        {
+            String channelName = StringArgumentType.getString(ctx, "channel");
+            Identifier id = Identifier.fromNamespaceAndPath("testmod", channelName);
+            ServerPlayer player = src.getPlayerOrException();
+
+            ChatChannel ch = ChatRouter.getInstance().getChannel(id);
+            if (ch == null)
+            {
+                src.sendFailure(Component.literal("[polytest] chat leave: channel '" + channelName + "' not found"));
+                return 0;
+            }
+            ch.removeMember(player.getUUID());
+            src.sendSuccess(() -> Component.literal("[polytest] chat leave: " + player.getScoreboardName() + " left " + id), false);
+        }
+        catch (Exception e)
+        {
+            src.sendFailure(Component.literal("[polytest] chat leave: " + e.getMessage()));
+        }
+        return 1;
+    }
+
+    // ----- /polytest chat say <channel> <message> -----
+    private static int testChatSay(CommandContext<CommandSourceStack> ctx)
+    {
+        CommandSourceStack src = ctx.getSource();
+        try
+        {
+            String channelName = StringArgumentType.getString(ctx, "channel");
+            String message     = StringArgumentType.getString(ctx, "message");
+            Identifier id      = Identifier.fromNamespaceAndPath("testmod", channelName);
+            ServerPlayer player = src.getPlayerOrException();
+
+            ChatChannel ch = ChatRouter.getInstance().getChannel(id);
+            if (ch == null)
+            {
+                src.sendFailure(Component.literal("[polytest] chat say: channel '" + channelName + "' not found — join it first"));
+                return 0;
+            }
+            ChatRouter.getInstance().routeMessage(id, RichChatMessage.create(Component.literal(message), player.getDisplayName()));
+            // Deliver as system messages so online members can see them in vanilla chat
+            Component formatted = Component.literal("[" + channelName + "] ")
+                    .append(player.getDisplayName())
+                    .append(Component.literal(": " + message));
+            for (ChatMember member : ch.getMembers())
+            {
+                ServerPlayer online = src.getServer().getPlayerList().getPlayer(member.memberId());
+                if (online != null) online.sendSystemMessage(formatted);
+            }
+            src.sendSuccess(() -> Component.literal("[polytest] chat say: message routed to " + id), false);
+        }
+        catch (Exception e)
+        {
+            src.sendFailure(Component.literal("[polytest] chat say: " + e.getMessage()));
         }
         return 1;
     }


### PR DESCRIPTION
## Chat System

Adds a client-side floating chat window framework on top of a channel/router abstraction.

### New classes

**common/chat/**
- \ChatChannel\ — isolated message stream with members, history, listeners, and pluggable submitHandler
- \ChatMember\ — record: UUID, displayName, icon, isOnline
- \ChatRouter\ — singleton registry; registerChannel, getChannel, getActiveChannels, routeMessage
- \RichChatMessage\ — value type wrapping content + sender Component

**common/chat/client/**
- \FloatingChatWindow\ — draggable GuiWindow with header, scrollable message area, member sidebar, optional input field (canReply)
- \ChatWindowManager\ — manages multiple windows with edge-snap-on-move

**common/chat/layout/**
- \ChatLayoutManager\ / \ChatWindowLayout\ — persists and restores window positions

**common/modulargui/elements/**
- \GuiWindow\ — new draggable, titled window base element
- \GuiButton\ — basic clickable button element

### Testmod demo

- \/polytest chat list/join/leave/say\
- Numpad 5 — opens FloatingChatWindow for every registered channel

Tested on Fabric and NeoForge.